### PR TITLE
Add configurable connection strings

### DIFF
--- a/MyWebApp/Program.cs
+++ b/MyWebApp/Program.cs
@@ -1,7 +1,15 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using MyWebApp.Data;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Allow connection string overrides from environment-specific files,
+// environment variables, and command-line arguments
+builder.Configuration
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+    .AddEnvironmentVariables()
+    .AddCommandLine(args);
 
 // Add services to the container.
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # AreaRecord
 Record a selected area with presets, hotkeys, and live stats.
+
+## Configuring the Database Connection
+
+`appsettings.json` contains the default connection string used by the
+application:
+
+```json
+"ConnectionStrings": {
+  "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MyWebAppDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+}
+```
+
+You can override this value in several ways:
+
+1. Create an `appsettings.{Environment}.json` file (for example
+   `appsettings.Production.json`) containing a different `DefaultConnection`.
+2. Set the environment variable `ConnectionStrings__DefaultConnection`.
+3. Pass a command‑line argument `--ConnectionStrings:DefaultConnection="<your connection string>"`.
+
+When switching to another provider (e.g. PostgreSQL or SQLite) update
+`Program.cs` so the `DbContext` uses the appropriate `Use*` method instead of
+`UseSqlServer`.


### PR DESCRIPTION
## Summary
- document how to configure database connection
- add config overrides for connection strings

## Testing
- `dotnet build MyWebApp/MyWebApp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848452785ec832ca5a9b274c5eae340