### PR TITLE
Add restore instructions and ignore build logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ obj/
 node_modules/
 dotnet-install.sh
 *.ico
+
+# Build logs
+*.log
+MyWebApp.Tests/TestResults/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # AreaRecord
 Record a selected area with presets, hotkeys, and live stats.
 
+## Restoring Dependencies
+
+After cloning the repository, restore the required packages:
+
+```bash
+dotnet restore
+libman restore
+```
+
 ## Configuring the Database Connection
 
 `appsettings.json` contains the default connection string used by the


### PR DESCRIPTION
## Summary
- add instructions for restoring packages in README
- ignore build logs and test results

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684849472cbc832c8280e3740a8efe8d