### PR TITLE
Implement captcha-protected download page

### DIFF
--- a/MyWebApp/Controllers/DownloadController.cs
+++ b/MyWebApp/Controllers/DownloadController.cs
@@ -1,0 +1,150 @@
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using MyWebApp.Data;
+using MyWebApp.Models;
+
+namespace MyWebApp.Controllers;
+
+public class DownloadController : Controller
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ILogger<DownloadController> _logger;
+    private readonly IMemoryCache _cache;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+
+    public DownloadController(ApplicationDbContext context,
+        ILogger<DownloadController> logger,
+        IMemoryCache cache,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration)
+    {
+        _context = context;
+        _logger = logger;
+        _cache = cache;
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+    }
+
+    [HttpGet]
+    public IActionResult Index()
+    {
+        ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
+        ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
+        return View();
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Index(string token)
+    {
+        var ip = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var userAgent = Request.Headers["User-Agent"].ToString();
+        var sessionId = HttpContext.Session.Id;
+
+        var download = new Download
+        {
+            UserIP = ip,
+            UserAgent = userAgent,
+            DownloadTime = DateTime.UtcNow,
+            SessionId = sessionId,
+            IsSuccessful = false
+        };
+
+        if (!ValidateUserAgent(userAgent))
+        {
+            _logger.LogWarning("Invalid user agent {Agent}", userAgent);
+            _context.Downloads.Add(download);
+            await _context.SaveChangesAsync();
+            ModelState.AddModelError(string.Empty, "Invalid request.");
+            ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
+            ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
+            return View();
+        }
+
+        if (IsRateLimited(ip))
+        {
+            _logger.LogInformation("Rate limit hit for {IP}", ip);
+            ModelState.AddModelError(string.Empty, "Please wait a few minutes before trying again.");
+            _context.Downloads.Add(download);
+            await _context.SaveChangesAsync();
+            ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
+            ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
+            return View();
+        }
+
+        if (!await VerifyCaptchaAsync(token, ip))
+        {
+            _logger.LogInformation("Captcha failed for {IP}", ip);
+            ModelState.AddModelError(string.Empty, "CAPTCHA validation failed.");
+            _context.Downloads.Add(download);
+            await _context.SaveChangesAsync();
+            ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
+            ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
+            return View();
+        }
+
+        download.IsSuccessful = true;
+        _context.Downloads.Add(download);
+        await _context.SaveChangesAsync();
+        SetRateLimit(ip);
+        return Redirect("https://chrome.google.com/webstore/detail/screen-area-recorder-pro");
+    }
+
+    private bool ValidateUserAgent(string userAgent) => !string.IsNullOrWhiteSpace(userAgent);
+
+    private bool IsRateLimited(string ip)
+    {
+        if (_cache.TryGetValue(ip, out _))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private void SetRateLimit(string ip)
+    {
+        var options = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5)
+        };
+        _cache.Set(ip, true, options);
+    }
+
+    private async Task<bool> VerifyCaptchaAsync(string token, string ip)
+    {
+        var secret = _configuration["Captcha:SecretKey"];
+        var verifyUrl = _configuration["Captcha:VerifyUrl"];
+        if (string.IsNullOrEmpty(secret) || string.IsNullOrEmpty(verifyUrl))
+        {
+            _logger.LogWarning("Captcha secret or verify url not configured");
+            return false;
+        }
+
+        var client = _httpClientFactory.CreateClient();
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "secret", secret },
+            { "response", token },
+            { "remoteip", ip }
+        });
+
+        try
+        {
+            var response = await client.PostAsync(verifyUrl, content);
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("success", out var success) && success.GetBoolean())
+            {
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Captcha verification failed");
+        }
+        return false;
+    }
+}

--- a/MyWebApp/Data/ApplicationDbContext.cs
+++ b/MyWebApp/Data/ApplicationDbContext.cs
@@ -12,5 +12,6 @@ namespace MyWebApp.Data
 
         // Add DbSet<> properties here
         public DbSet<Recording> Recordings { get; set; }
+        public DbSet<Download> Downloads { get; set; }
     }
 }

--- a/MyWebApp/Migrations/20250611051150_AddDownloadsTable.Designer.cs
+++ b/MyWebApp/Migrations/20250611051150_AddDownloadsTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyWebApp.Data;
 
@@ -11,9 +12,11 @@ using MyWebApp.Data;
 namespace MyWebApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250611051150_AddDownloadsTable")]
+    partial class AddDownloadsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MyWebApp/Migrations/20250611051150_AddDownloadsTable.cs
+++ b/MyWebApp/Migrations/20250611051150_AddDownloadsTable.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyWebApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDownloadsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Downloads",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserIP = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    UserAgent = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DownloadTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsSuccessful = table.Column<bool>(type: "bit", nullable: false),
+                    SessionId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Country = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Downloads", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Downloads");
+        }
+    }
+}

--- a/MyWebApp/Models/Download.cs
+++ b/MyWebApp/Models/Download.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace MyWebApp.Models
+{
+    public class Download
+    {
+        public int Id { get; set; }
+        public string UserIP { get; set; } = string.Empty;
+        public string UserAgent { get; set; } = string.Empty;
+        public DateTime DownloadTime { get; set; }
+        public bool IsSuccessful { get; set; }
+        public string? SessionId { get; set; }
+        public string? Country { get; set; }
+    }
+}

--- a/MyWebApp/Program.cs
+++ b/MyWebApp/Program.cs
@@ -17,6 +17,9 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddDbContext<MyWebApp.Data.ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddControllersWithViews();
+builder.Services.AddMemoryCache();
+builder.Services.AddHttpClient();
+builder.Services.AddSession();
 
 var app = builder.Build();
 
@@ -32,6 +35,8 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.UseSession();
 
 app.UseAuthorization();
 

--- a/MyWebApp/Views/Download/Index.cshtml
+++ b/MyWebApp/Views/Download/Index.cshtml
@@ -1,0 +1,31 @@
+@{
+    ViewData["Title"] = "Download";
+}
+
+<h1>Download Screen Area Recorder Pro</h1>
+
+<p>Total downloads: @ViewBag.TotalDownloads</p>
+
+<form method="post" asp-controller="Download" asp-action="Index" id="download-form">
+    <input type="hidden" name="token" id="captcha-token" />
+    <button class="download-btn" type="submit" id="download-btn" disabled>Download Extension</button>
+</form>
+
+<div class="validation-summary">
+    @foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors))
+    {
+        <p class="text-danger">@error.ErrorMessage</p>
+    }
+</div>
+
+@section Scripts {
+    <script src="https://www.google.com/recaptcha/api.js?render=@ViewBag.SiteKey"></script>
+    <script>
+        grecaptcha.ready(function () {
+            grecaptcha.execute('@ViewBag.SiteKey', { action: 'download' }).then(function (token) {
+                document.getElementById('captcha-token').value = token;
+                document.getElementById('download-btn').disabled = false;
+            });
+        });
+    </script>
+}

--- a/MyWebApp/Views/Shared/_Layout.cshtml
+++ b/MyWebApp/Views/Shared/_Layout.cshtml
@@ -12,6 +12,7 @@
             <a class="logo" asp-area="" asp-controller="Home" asp-action="Index">Screen Area Recorder Pro</a>
             <nav class="site-nav">
                 <a asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                <a asp-area="" asp-controller="Download" asp-action="Index">Download</a>
                 <a asp-area="" asp-controller="Home" asp-action="Faq">FAQ</a>
                 <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
             </nav>

--- a/MyWebApp/appsettings.json
+++ b/MyWebApp/appsettings.json
@@ -8,5 +8,10 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MyWebAppDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Captcha": {
+    "SiteKey": "YOUR_SITE_KEY",
+    "SecretKey": "YOUR_SECRET_KEY",
+    "VerifyUrl": "https://www.google.com/recaptcha/api/siteverify"
   }
 }


### PR DESCRIPTION
## Summary
- add `Download` model and EF migration
- log download attempts and enforce CAPTCHA in `DownloadController`
- expose new download page view
- register MemoryCache, HttpClient and Session middleware
- display Download link in navigation

## Testing
- `dotnet build MyWebApp.sln -c Release`
- `dotnet test MyWebApp.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68490f8d603c832c8bb71b896b038eba