### PR TITLE
Add setup diagnostics page

### DIFF
--- a/website/MyWebApp.Tests/SetupControllerTests.cs
+++ b/website/MyWebApp.Tests/SetupControllerTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Controllers;
+using MyWebApp.Data;
+using Xunit;
+
+public class SetupControllerTests
+{
+    [Fact]
+    public void Index_ReturnsView_WithBooleanModel()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase("SetupSuccessDb")
+            .Options;
+        using var context = new ApplicationDbContext(options);
+        var controller = new SetupController(context);
+
+        var result = controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.IsType<bool>(viewResult.Model);
+    }
+
+    [Fact]
+    public void Index_HandlesConnectionFailure()
+    {
+        var options = new DbContextOptions<ApplicationDbContext>();
+        using var context = new ApplicationDbContext(options);
+        var controller = new SetupController(context);
+
+        var result = controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.False((bool)viewResult.Model);
+    }
+}

--- a/website/MyWebApp/Controllers/SetupController.cs
+++ b/website/MyWebApp/Controllers/SetupController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+using MyWebApp.Data;
+
+namespace MyWebApp.Controllers;
+
+public class SetupController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public SetupController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IActionResult Index()
+    {
+        bool canConnect;
+        try
+        {
+            canConnect = _context.Database.CanConnect();
+        }
+        catch
+        {
+            canConnect = false;
+        }
+        return View(canConnect);
+    }
+}

--- a/website/MyWebApp/Views/Setup/Index.cshtml
+++ b/website/MyWebApp/Views/Setup/Index.cshtml
@@ -1,0 +1,16 @@
+@model bool
+@{
+    ViewData["Title"] = "Setup";
+}
+
+<h1>Setup</h1>
+
+@if (Model)
+{
+    <p>Database connection successful.</p>
+}
+else
+{
+    <p>Database connection failed.</p>
+    <p>Please verify your connection string and ensure the database server is running.</p>
+}

--- a/website/MyWebApp/Views/Shared/_Layout.cshtml
+++ b/website/MyWebApp/Views/Shared/_Layout.cshtml
@@ -15,6 +15,7 @@
                 <a asp-area="" asp-controller="Download" asp-action="Index">Download</a>
                 <a asp-area="" asp-controller="Home" asp-action="Faq">FAQ</a>
                 <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+                <a asp-area="" asp-controller="Setup" asp-action="Index">Setup</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- add a SetupController with DB connectivity check
- show status message in Setup/Index view
- link the new page from the layout
- test SetupController connection logic

## Testing
- `dotnet restore MyWebApp.sln`
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684916074d7c832cae309b95cf594e4c