### PR TITLE
Allow selecting database provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,25 @@ libman restore
 
 ## Configuring the Database Connection
 
-`appsettings.json` contains the default connection string used by the
-application:
+`appsettings.json` contains the default connection string and the provider
+selection used by the application:
 
 ```json
 "ConnectionStrings": {
   "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MyWebAppDb;Trusted_Connection=True;MultipleActiveResultSets=true"
-}
+},
+"DatabaseProvider": "SqlServer"
 ```
 
-You can override this value in several ways:
+You can override these values in several ways:
 
 1. Create an `appsettings.{Environment}.json` file (for example
    `appsettings.Production.json`) containing a different `DefaultConnection`.
 2. Set the environment variable `ConnectionStrings__DefaultConnection`.
 3. Pass a command‑line argument `--ConnectionStrings:DefaultConnection="<your connection string>"`.
+4. Set `DatabaseProvider` (`SqlServer`, `PostgreSQL` or `Sqlite`) using the same methods above.
 
-When switching to another provider (e.g. PostgreSQL or SQLite) update
-`Program.cs` so the `DbContext` uses the appropriate `Use*` method instead of
-`UseSqlServer`.
+Specify `DatabaseProvider` when switching providers; `Program.cs` will pick the correct `Use*` method automatically.
 
 ## Database Migrations
 

--- a/website/MyWebApp/MyWebApp.csproj
+++ b/website/MyWebApp/MyWebApp.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using MyWebApp.Data;
+using Npgsql.EntityFrameworkCore.PostgreSQL;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,8 +15,23 @@ builder.Configuration
 // Add services to the container.
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
     ?? "Server=(localdb)\\mssqllocaldb;Database=MyWebAppDb;Trusted_Connection=True;MultipleActiveResultSets=true";
+var provider = builder.Configuration["DatabaseProvider"] ?? "SqlServer";
 builder.Services.AddDbContext<MyWebApp.Data.ApplicationDbContext>(options =>
-    options.UseSqlServer(connectionString));
+{
+    switch (provider.ToLowerInvariant())
+    {
+        case "postgresql":
+        case "npgsql":
+            options.UseNpgsql(connectionString);
+            break;
+        case "sqlite":
+            options.UseSqlite(connectionString);
+            break;
+        default:
+            options.UseSqlServer(connectionString);
+            break;
+    }
+});
 builder.Services.AddControllersWithViews();
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();

--- a/website/MyWebApp/appsettings.json
+++ b/website/MyWebApp/appsettings.json
@@ -9,6 +9,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MyWebAppDb;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
+  "DatabaseProvider": "SqlServer",
   "Captcha": {
     "SiteKey": "YOUR_SITE_KEY",
     "SecretKey": "YOUR_SECRET_KEY",


### PR DESCRIPTION
## Summary
- add optional EF Core provider packages
- configure `DatabaseProvider` setting with default `SqlServer`
- choose `Use*` method in Program.cs based on configuration
- document provider selection in README

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684965530eb8832cb0a4624f682c925c