### PR TITLE
Add automatic database migration at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ To generate a SQL script that can be executed manually or on another server, use
 dotnet ef migrations script > update.sql
 ```
 
+When the application starts it attempts to connect to the configured database.
+If the connection succeeds, `Program.cs` automatically runs
+`db.Database.Migrate()` to apply any pending migrations. If a connection cannot
+be established, a warning is logged and the app continues to run.
+
 ## Deploying Migrations Remotely
 
 1. Build the project and ensure migrations compile.
@@ -97,5 +102,6 @@ dotnet run
 ```
 
 2. With the site running, open your browser to `/Setup` to confirm the
-   database connection can be established. Ensure all migrations have been
-   applied with `dotnet ef database update` before visiting this page.
+   database connection can be established. Migrations are applied automatically
+   at startup when a connection is available, but you can still run
+   `dotnet ef database update` manually if needed.

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -39,6 +39,20 @@ builder.Services.AddSession();
 
 var app = builder.Build();
 
+// Ensure database is up to date
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    if (db.Database.CanConnect())
+    {
+        db.Database.Migrate();
+    }
+    else
+    {
+        app.Logger.LogWarning("Could not connect to the database. Migrations were not applied.");
+    }
+}
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- update `Program.cs` to apply EF Core migrations when the app can connect to the database
- describe startup migration behaviour in the README

## Testing
- `dotnet build MyWebApp.sln -c Debug`
- `dotnet test MyWebApp.sln`


------
https://chatgpt.com/codex/tasks/task_e_6849752a7fd4832c9f5943a54d1d1c19