### PR TITLE
Handle SaveChanges failures and add setup import page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 bin/
 obj/
 *.dll
-*/wwwroot/lib/
+**/wwwroot/lib/
 node_modules/
 dotnet-install.sh
 *.ico
 
 # Build logs
 *.log
-MyWebApp.Tests/TestResults/
+website/MyWebApp.Tests/TestResults/

--- a/README.md
+++ b/README.md
@@ -105,3 +105,8 @@ dotnet run
    database connection can be established. Migrations are applied automatically
    at startup when a connection is available, but you can still run
    `dotnet ef database update` manually if needed.
+
+3. For a quick reminder on how to import data or apply migrations manually,
+   visit `/Setup/Import` while the site is running. The page shows the shell
+   commands used to update the schema and execute a generated `update.sql`
+   script using `sqlcmd`.

--- a/website/MyWebApp/Controllers/DownloadController.cs
+++ b/website/MyWebApp/Controllers/DownloadController.cs
@@ -57,7 +57,14 @@ public class DownloadController : Controller
         {
             _logger.LogWarning("Invalid user agent {Agent}", userAgent);
             _context.Downloads.Add(download);
-            await _context.SaveChangesAsync();
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save download");
+            }
             ModelState.AddModelError(string.Empty, "Invalid request.");
             ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
             ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
@@ -69,7 +76,14 @@ public class DownloadController : Controller
             _logger.LogInformation("Rate limit hit for {IP}", ip);
             ModelState.AddModelError(string.Empty, "Please wait a few minutes before trying again.");
             _context.Downloads.Add(download);
-            await _context.SaveChangesAsync();
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save download");
+            }
             ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
             ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
             return View();
@@ -80,7 +94,14 @@ public class DownloadController : Controller
             _logger.LogInformation("Captcha failed for {IP}", ip);
             ModelState.AddModelError(string.Empty, "CAPTCHA validation failed.");
             _context.Downloads.Add(download);
-            await _context.SaveChangesAsync();
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save download");
+            }
             ViewBag.TotalDownloads = _context.Downloads.Count(d => d.IsSuccessful);
             ViewBag.SiteKey = _configuration["Captcha:SiteKey"] ?? string.Empty;
             return View();
@@ -88,7 +109,14 @@ public class DownloadController : Controller
 
         download.IsSuccessful = true;
         _context.Downloads.Add(download);
-        await _context.SaveChangesAsync();
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save download");
+        }
         SetRateLimit(ip);
         return Redirect("https://chrome.google.com/webstore/detail/screen-area-recorder-pro");
     }

--- a/website/MyWebApp/Controllers/HomeController.cs
+++ b/website/MyWebApp/Controllers/HomeController.cs
@@ -18,7 +18,14 @@ public class HomeController : Controller
     public IActionResult Index()
     {
         _context.Recordings.Add(new Recording { Name = "Visit", Created = DateTime.UtcNow });
-        _context.SaveChanges();
+        try
+        {
+            _context.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save recording");
+        }
         return View();
     }
 

--- a/website/MyWebApp/Controllers/SetupController.cs
+++ b/website/MyWebApp/Controllers/SetupController.cs
@@ -25,4 +25,9 @@ public class SetupController : Controller
         }
         return View(canConnect);
     }
+
+    public IActionResult Import()
+    {
+        return View();
+    }
 }

--- a/website/MyWebApp/Views/Setup/Import.cshtml
+++ b/website/MyWebApp/Views/Setup/Import.cshtml
@@ -1,0 +1,14 @@
+@{
+    ViewData["Title"] = "Import";
+}
+
+<h1>Import Data</h1>
+
+<p>Run the following commands from the <code>website/MyWebApp</code> directory to create or update the database schema and import data:</p>
+
+<pre><code>dotnet ef database update
+sqlcmd -S <server> -d <database> -i update.sql
+</code></pre>
+
+<p>The <code>update.sql</code> file can be generated using <code>dotnet ef migrations script &gt; update.sql</code>.</p>
+

--- a/website/MyWebApp/Views/Setup/Index.cshtml
+++ b/website/MyWebApp/Views/Setup/Index.cshtml
@@ -14,3 +14,5 @@ else
     <p>Database connection failed.</p>
     <p>Please verify your connection string and ensure the database server is running.</p>
 }
+
+<p><a href="/Setup/Import">Import data instructions</a></p>


### PR DESCRIPTION
## Summary
- ignore binary assets under `wwwroot/lib`
- add try/catch around `SaveChanges` calls
- add `/Setup/Import` page with shell commands
- link to import instructions from setup page
- document new page in README

## Testing
- `dotnet test MyWebApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849940670c8832caefc9c89693a1c02