### PR TITLE
Add DB error handling and setup improvements

### DIFF
--- a/website/MyWebApp.Tests/SetupControllerTests.cs
+++ b/website/MyWebApp.Tests/SetupControllerTests.cs
@@ -2,23 +2,27 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using MyWebApp.Controllers;
 using MyWebApp.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Configuration;
+using MyWebApp.Models;
 using Xunit;
 
 public class SetupControllerTests
 {
     [Fact]
-    public void Index_ReturnsView_WithBooleanModel()
+    public void Index_ReturnsView_WithModel()
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase("SetupSuccessDb")
             .Options;
         using var context = new ApplicationDbContext(options);
-        var controller = new SetupController(context);
+        var config = new ConfigurationBuilder().Build();
+        var controller = new SetupController(context, config, NullLogger<SetupController>.Instance);
 
         var result = controller.Index();
 
         var viewResult = Assert.IsType<ViewResult>(result);
-        Assert.IsType<bool>(viewResult.Model);
+        Assert.IsType<SetupViewModel>(viewResult.Model);
     }
 
     [Fact]
@@ -26,11 +30,13 @@ public class SetupControllerTests
     {
         var options = new DbContextOptions<ApplicationDbContext>();
         using var context = new ApplicationDbContext(options);
-        var controller = new SetupController(context);
+        var config = new ConfigurationBuilder().Build();
+        var controller = new SetupController(context, config, NullLogger<SetupController>.Instance);
 
         var result = controller.Index();
 
         var viewResult = Assert.IsType<ViewResult>(result);
-        Assert.False((bool)viewResult.Model);
+        var model = Assert.IsType<SetupViewModel>(viewResult.Model);
+        Assert.False(model.CanConnect);
     }
 }

--- a/website/MyWebApp/Controllers/BaseController.cs
+++ b/website/MyWebApp/Controllers/BaseController.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using MyWebApp.Data;
+
+namespace MyWebApp.Controllers;
+
+public abstract class BaseController : Controller
+{
+    protected readonly ApplicationDbContext Db;
+    protected readonly ILogger Logger;
+
+    protected BaseController(ApplicationDbContext db, ILogger logger)
+    {
+        Db = db;
+        Logger = logger;
+    }
+
+    protected bool CheckDatabase()
+    {
+        try
+        {
+            return Db.Database.CanConnect();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Database connectivity check failed");
+            return false;
+        }
+    }
+
+    protected IActionResult RedirectToSetup(Exception? ex = null)
+    {
+        if (ex != null)
+        {
+            Logger.LogError(ex, "Database operation failed");
+            TempData["DbError"] = ex.Message;
+        }
+        else
+        {
+            TempData["DbError"] = "Database connection failed";
+        }
+        return RedirectToAction("Index", "Setup");
+    }
+}

--- a/website/MyWebApp/Controllers/HomeController.cs
+++ b/website/MyWebApp/Controllers/HomeController.cs
@@ -4,27 +4,28 @@ using MyWebApp.Models;
 
 namespace MyWebApp.Controllers;
 
-public class HomeController : Controller
+public class HomeController : BaseController
 {
-    private readonly ILogger<HomeController> _logger;
-    private readonly MyWebApp.Data.ApplicationDbContext _context;
-
     public HomeController(ILogger<HomeController> logger, MyWebApp.Data.ApplicationDbContext context)
+        : base(context, logger)
     {
-        _logger = logger;
-        _context = context;
     }
 
     public IActionResult Index()
     {
-        _context.Recordings.Add(new Recording { Name = "Visit", Created = DateTime.UtcNow });
+        if (!CheckDatabase())
+        {
+            return RedirectToSetup();
+        }
+
+        Db.Recordings.Add(new Recording { Name = "Visit", Created = DateTime.UtcNow });
         try
         {
-            _context.SaveChanges();
+            Db.SaveChanges();
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to save recording");
+            return RedirectToSetup(ex);
         }
         return View();
     }

--- a/website/MyWebApp/Controllers/SetupController.cs
+++ b/website/MyWebApp/Controllers/SetupController.cs
@@ -1,33 +1,113 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using MyWebApp.Data;
+using MyWebApp.Models;
 
 namespace MyWebApp.Controllers;
 
-public class SetupController : Controller
+public class SetupController : BaseController
 {
-    private readonly ApplicationDbContext _context;
+    private readonly IConfiguration _config;
 
-    public SetupController(ApplicationDbContext context)
+    public SetupController(ApplicationDbContext context, IConfiguration config, ILogger<SetupController> logger)
+        : base(context, logger)
     {
-        _context = context;
+        _config = config;
     }
 
     public IActionResult Index()
     {
-        bool canConnect;
-        try
+        var error = TempData != null ? TempData["DbError"]?.ToString() : null;
+        var result = TempData != null ? TempData["SetupResult"]?.ToString() : null;
+        var model = new SetupViewModel
         {
-            canConnect = _context.Database.CanConnect();
-        }
-        catch
-        {
-            canConnect = false;
-        }
-        return View(canConnect);
+            CanConnect = CheckDatabase(),
+            ConnectionString = _config.GetConnectionString("DefaultConnection") ?? string.Empty,
+            Provider = _config["DatabaseProvider"] ?? "SqlServer",
+            ErrorMessage = error,
+            ResultMessage = result
+        };
+        return View(model);
     }
 
-    public IActionResult Import()
+    [HttpPost]
+    public IActionResult UseSqlite()
     {
-        return View();
+        if (_config is IConfigurationRoot root)
+        {
+            foreach (var provider in root.Providers)
+            {
+                provider.Set("ConnectionStrings:DefaultConnection", "Data Source=mywebapp.db");
+                provider.Set("DatabaseProvider", "Sqlite");
+            }
+        }
+        TempData["SetupResult"] = "Switched to SQLite.";
+        return RedirectToAction(nameof(Index));
     }
+
+    [HttpPost]
+    public IActionResult Test(string connectionString, string provider)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        switch (provider.ToLowerInvariant())
+        {
+            case "npgsql":
+            case "postgresql":
+                optionsBuilder.UseNpgsql(connectionString);
+                break;
+            case "sqlite":
+                optionsBuilder.UseSqlite(connectionString);
+                break;
+            default:
+                optionsBuilder.UseSqlServer(connectionString);
+                break;
+        }
+
+        try
+        {
+            using var testDb = new ApplicationDbContext(optionsBuilder.Options);
+            TempData["SetupResult"] = testDb.Database.CanConnect() ? "Connection successful" : "Connection failed";
+        }
+        catch (Exception ex)
+        {
+            TempData["SetupResult"] = "Connection failed: " + ex.Message;
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    public IActionResult Seed()
+    {
+        if (!CheckDatabase())
+        {
+            return RedirectToSetup();
+        }
+
+        try
+        {
+            if (!Db.Recordings.Any())
+            {
+                Db.Recordings.AddRange(
+                    new Recording { Name = "Sample1", Created = DateTime.UtcNow },
+                    new Recording { Name = "Sample2", Created = DateTime.UtcNow }
+                );
+            }
+            if (!Db.Downloads.Any())
+            {
+                Db.Downloads.AddRange(
+                    new Download { UserIP = "127.0.0.1", UserAgent = "seed", DownloadTime = DateTime.UtcNow, IsSuccessful = true },
+                    new Download { UserIP = "127.0.0.2", UserAgent = "seed", DownloadTime = DateTime.UtcNow, IsSuccessful = false }
+                );
+            }
+            Db.SaveChanges();
+            TempData["SetupResult"] = "Sample data inserted.";
+        }
+        catch (Exception ex)
+        {
+            TempData["SetupResult"] = "Seeding failed: " + ex.Message;
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    public IActionResult Import() => View();
 }

--- a/website/MyWebApp/Models/SetupViewModel.cs
+++ b/website/MyWebApp/Models/SetupViewModel.cs
@@ -1,0 +1,10 @@
+namespace MyWebApp.Models;
+
+public class SetupViewModel
+{
+    public bool CanConnect { get; set; }
+    public string ConnectionString { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+    public string? ErrorMessage { get; set; }
+    public string? ResultMessage { get; set; }
+}

--- a/website/MyWebApp/Views/Setup/Index.cshtml
+++ b/website/MyWebApp/Views/Setup/Index.cshtml
@@ -1,18 +1,47 @@
-@model bool
+@model SetupViewModel
 @{
     ViewData["Title"] = "Setup";
 }
 
 <h1>Setup</h1>
 
-@if (Model)
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="alert alert-danger">@Model.ErrorMessage</div>
+}
+@if (!string.IsNullOrEmpty(Model.ResultMessage))
+{
+    <div class="alert alert-info">@Model.ResultMessage</div>
+}
+
+<p>Current provider: @Model.Provider</p>
+<p>Connection string: @Model.ConnectionString</p>
+
+@if (Model.CanConnect)
 {
     <p>Database connection successful.</p>
 }
 else
 {
     <p>Database connection failed.</p>
-    <p>Please verify your connection string and ensure the database server is running.</p>
+    <form method="post" asp-action="UseSqlite">
+        <button type="submit">Use SQLite Fallback</button>
+    </form>
 }
+
+<h2>Test Connection</h2>
+<form method="post" asp-action="Test">
+    <input type="text" name="connectionString" value="@Model.ConnectionString" />
+    <select name="provider">
+        <option value="SqlServer" selected="@(Model.Provider=="SqlServer")">SQL Server</option>
+        <option value="PostgreSQL" selected="@(Model.Provider=="PostgreSQL")">PostgreSQL</option>
+        <option value="Sqlite" selected="@(Model.Provider=="Sqlite")">SQLite</option>
+    </select>
+    <button type="submit">Test</button>
+</form>
+
+<form method="post" asp-action="Seed">
+    <button type="submit">Seed Sample Data</button>
+</form>
 
 <p><a href="/Setup/Import">Import data instructions</a></p>


### PR DESCRIPTION
## Summary
- add `BaseController` for common DB checks
- update `HomeController`, `DownloadController`, and `SetupController` to use it
- implement fallback logic and sample data seeding in Setup
- extend Setup UI for provider switching and connection tests
- add SQLite fallback detection in `Program`
- adjust unit tests for new Setup flow

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684ad6221db0832c957c326b7a606bad