### PR TITLE
Add connection save button

### DIFF
--- a/website/MyWebApp.Tests/SetupControllerTests.cs
+++ b/website/MyWebApp.Tests/SetupControllerTests.cs
@@ -5,7 +5,19 @@ using MyWebApp.Data;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Configuration;
 using MyWebApp.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
 using Xunit;
+
+class FakeEnv : IWebHostEnvironment
+{
+    public string EnvironmentName { get; set; } = "Development";
+    public string ApplicationName { get; set; } = "Test";
+    public string WebRootPath { get; set; } = "/tmp";
+    public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    public string ContentRootPath { get; set; } = "/tmp";
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}
 
 public class SetupControllerTests
 {
@@ -17,7 +29,8 @@ public class SetupControllerTests
             .Options;
         using var context = new ApplicationDbContext(options);
         var config = new ConfigurationBuilder().Build();
-        var controller = new SetupController(context, config, NullLogger<SetupController>.Instance);
+        var env = new FakeEnv();
+        var controller = new SetupController(context, config, NullLogger<SetupController>.Instance, env);
 
         var result = controller.Index();
 
@@ -31,7 +44,8 @@ public class SetupControllerTests
         var options = new DbContextOptions<ApplicationDbContext>();
         using var context = new ApplicationDbContext(options);
         var config = new ConfigurationBuilder().Build();
-        var controller = new SetupController(context, config, NullLogger<SetupController>.Instance);
+        var env = new FakeEnv();
+        var controller = new SetupController(context, config, NullLogger<SetupController>.Instance, env);
 
         var result = controller.Index();
 

--- a/website/MyWebApp/Views/Setup/Index.cshtml
+++ b/website/MyWebApp/Views/Setup/Index.cshtml
@@ -30,14 +30,15 @@ else
 }
 
 <h2>Test Connection</h2>
-<form method="post" asp-action="Test">
-    <input type="text" name="connectionString" value="@Model.ConnectionString" />
+<form method="post" action="@Url.Action("Test")">
+    <input type="text" name="connectionString" value="@Model.ConnectionString" style="width:600px" />
     <select name="provider">
         <option value="SqlServer" selected="@(Model.Provider=="SqlServer")">SQL Server</option>
         <option value="PostgreSQL" selected="@(Model.Provider=="PostgreSQL")">PostgreSQL</option>
         <option value="Sqlite" selected="@(Model.Provider=="Sqlite")">SQLite</option>
     </select>
     <button type="submit">Test</button>
+    <button type="submit" formaction="@Url.Action("Save")">Save</button>
 </form>
 
 <form method="post" asp-action="Seed">


### PR DESCRIPTION
## Summary
- add config save logic in `SetupController`
- stub `IWebHostEnvironment` for unit tests
- enlarge connection input and add Save button in setup view

## Testing
- `dotnet restore MyWebApp.sln`
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684adf55ac84832cbf3f5aa2b99904d7