### PR TITLE
Update setup and admin pages for easier DB config

### DIFF
--- a/website/MyWebApp/Controllers/AdminController.cs
+++ b/website/MyWebApp/Controllers/AdminController.cs
@@ -3,9 +3,13 @@ using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 using MyWebApp.Data;
 using MyWebApp.Filters;
 using MyWebApp.Models;
+using Microsoft.AspNetCore.Hosting;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace MyWebApp.Controllers
 {
@@ -14,12 +18,29 @@ namespace MyWebApp.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly ILogger<AdminController> _logger;
+        private readonly IConfiguration _config;
+        private readonly IWebHostEnvironment _env;
         private static readonly DateTime _startTime = DateTime.UtcNow;
 
-        public AdminController(ApplicationDbContext context, ILogger<AdminController> logger)
+        public AdminController(ApplicationDbContext context, ILogger<AdminController> logger, IConfiguration config, IWebHostEnvironment env)
         {
             _context = context;
             _logger = logger;
+            _config = config;
+            _env = env;
+        }
+
+        private bool CheckDatabase()
+        {
+            try
+            {
+                return _context.Database.CanConnect();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Database connectivity check failed");
+                return false;
+            }
         }
 
         public IActionResult Index()
@@ -109,6 +130,91 @@ namespace MyWebApp.Controllers
             ViewBag.CountryData = country;
             ViewBag.AgentData = agents;
             return View();
+        }
+
+        public IActionResult DbSettings()
+        {
+            var connection = _config.GetConnectionString("DefaultConnection") ?? string.Empty;
+            var provider = _config["DatabaseProvider"] ?? "SqlServer";
+            ConnectionHelper.ParseConnectionString(provider, connection, out var server, out var database, out var user, out var pass);
+            var model = new SetupViewModel
+            {
+                CanConnect = CheckDatabase(),
+                ConnectionString = connection,
+                Provider = provider,
+                Server = server,
+                Database = database,
+                Username = user,
+                Password = pass
+            };
+            return View(model);
+        }
+
+        [HttpPost]
+        public IActionResult TestDb(string provider, string server, string database, string username, string password)
+        {
+            var conn = ConnectionHelper.BuildConnectionString(provider, server, database, username, password);
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            switch (provider.ToLowerInvariant())
+            {
+                case "npgsql":
+                case "postgresql":
+                    optionsBuilder.UseNpgsql(conn);
+                    break;
+                case "sqlite":
+                    optionsBuilder.UseSqlite(conn);
+                    break;
+                default:
+                    optionsBuilder.UseSqlServer(conn);
+                    break;
+            }
+
+            try
+            {
+                using var testDb = new ApplicationDbContext(optionsBuilder.Options);
+                TempData["SetupResult"] = testDb.Database.CanConnect() ? "Connection successful" : "Connection failed";
+            }
+            catch (Exception ex)
+            {
+                TempData["SetupResult"] = "Connection failed: " + ex.Message;
+            }
+            return RedirectToAction(nameof(DbSettings));
+        }
+
+        [HttpPost]
+        public IActionResult SaveDb(string provider, string server, string database, string username, string password)
+        {
+            try
+            {
+                var conn = ConnectionHelper.BuildConnectionString(provider, server, database, username, password);
+                var path = System.IO.Path.Combine(_env.ContentRootPath, "appsettings.json");
+                var json = System.IO.File.ReadAllText(path);
+                var obj = JsonNode.Parse(json)?.AsObject() ?? new JsonObject();
+                if (obj["ConnectionStrings"] is not JsonObject cs)
+                {
+                    cs = new JsonObject();
+                    obj["ConnectionStrings"] = cs;
+                }
+                cs["DefaultConnection"] = conn;
+                obj["DatabaseProvider"] = provider;
+                System.IO.File.WriteAllText(path, obj.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+                if (_config is IConfigurationRoot root)
+                {
+                    foreach (var p in root.Providers)
+                    {
+                        p.Set("ConnectionStrings:DefaultConnection", conn);
+                        p.Set("DatabaseProvider", provider);
+                    }
+                }
+
+                TempData["SetupResult"] = "Configuration saved.";
+            }
+            catch (Exception ex)
+            {
+                TempData["SetupResult"] = "Save failed: " + ex.Message;
+            }
+            return RedirectToAction(nameof(DbSettings));
         }
 
         public IActionResult Logs()

--- a/website/MyWebApp/Models/ConnectionHelper.cs
+++ b/website/MyWebApp/Models/ConnectionHelper.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace MyWebApp.Models;
+
+public static class ConnectionHelper
+{
+    public static string BuildConnectionString(string provider, string server, string database, string username, string password)
+    {
+        switch (provider.ToLowerInvariant())
+        {
+            case "postgresql":
+            case "npgsql":
+                return $"Host={server};Database={database};Username={username};Password={password}";
+            case "sqlite":
+                return $"Data Source={database}";
+            default:
+                if (string.IsNullOrEmpty(username))
+                {
+                    return $"Server={server};Database={database};Trusted_Connection=True;TrustServerCertificate=true";
+                }
+                return $"Server={server};Database={database};User Id={username};Password={password};TrustServerCertificate=true";
+        }
+    }
+
+    public static void ParseConnectionString(string provider, string connectionString, out string server, out string database, out string username, out string password)
+    {
+        server = database = username = password = string.Empty;
+        if (string.IsNullOrEmpty(connectionString))
+            return;
+
+        var parts = connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in parts)
+        {
+            var kv = part.Split('=', 2);
+            if (kv.Length != 2) continue;
+            var key = kv[0].Trim().ToLowerInvariant();
+            var value = kv[1].Trim();
+            switch (key)
+            {
+                case "server":
+                case "data source":
+                case "host":
+                    server = value;
+                    break;
+                case "database":
+                case "initial catalog":
+                    database = value;
+                    break;
+                case "user id":
+                case "username":
+                case "uid":
+                    username = value;
+                    break;
+                case "password":
+                case "pwd":
+                    password = value;
+                    break;
+            }
+        }
+    }
+}

--- a/website/MyWebApp/Models/SetupViewModel.cs
+++ b/website/MyWebApp/Models/SetupViewModel.cs
@@ -5,6 +5,10 @@ public class SetupViewModel
     public bool CanConnect { get; set; }
     public string ConnectionString { get; set; } = string.Empty;
     public string Provider { get; set; } = string.Empty;
+    public string Server { get; set; } = string.Empty;
+    public string Database { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
     public string? ErrorMessage { get; set; }
     public string? ResultMessage { get; set; }
 }

--- a/website/MyWebApp/Views/Admin/DbSettings.cshtml
+++ b/website/MyWebApp/Views/Admin/DbSettings.cshtml
@@ -1,36 +1,20 @@
 @model SetupViewModel
 @{
-    ViewData["Title"] = "Setup";
+    ViewData["Title"] = "Database Settings";
+    Layout = "_AdminLayout";
 }
-
-<h1>Setup</h1>
-
-@if (!string.IsNullOrEmpty(Model.ErrorMessage))
-{
-    <div class="alert alert-danger">@Model.ErrorMessage</div>
-}
+<h2>Database Settings</h2>
 @if (!string.IsNullOrEmpty(Model.ResultMessage))
 {
     <div class="alert alert-info">@Model.ResultMessage</div>
 }
-
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="alert alert-danger">@Model.ErrorMessage</div>
+}
 <p>Current provider: @Model.Provider</p>
 <p>Connection string: @Model.ConnectionString</p>
-
-@if (Model.CanConnect)
-{
-    <p>Database connection successful.</p>
-}
-else
-{
-    <p>Database connection failed.</p>
-    <form method="post" asp-action="UseSqlite">
-        <button type="submit">Use SQLite Fallback</button>
-    </form>
-}
-
-<h2>Test Connection</h2>
-<form method="post" action="@Url.Action("Test")">
+<form method="post" action="@Url.Action("TestDb")">
     <div>
         <label>Provider:</label>
         <select name="provider">
@@ -44,11 +28,5 @@ else
     <div><label>User:</label> <input type="text" name="username" value="@Model.Username" /></div>
     <div><label>Password:</label> <input type="password" name="password" value="@Model.Password" /></div>
     <button type="submit">Test</button>
-    <button type="submit" formaction="@Url.Action("Save")">Save</button>
+    <button type="submit" formaction="@Url.Action("SaveDb")">Save</button>
 </form>
-
-<form method="post" asp-action="Seed">
-    <button type="submit">Seed Sample Data</button>
-</form>
-
-<p><a href="/Setup/Import">Import data instructions</a></p>

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -19,6 +19,7 @@
                 <a asp-controller="Admin" asp-action="Index">Dashboard</a>
                 <a asp-controller="Admin" asp-action="Downloads">Downloads</a>
                 <a asp-controller="Admin" asp-action="Stats">Stats</a>
+                <a asp-controller="Admin" asp-action="DbSettings">DB Settings</a>
                 <a asp-controller="Admin" asp-action="Logs">Logs</a>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- enhance `SetupViewModel` with DB fields
- add `ConnectionHelper` for building and parsing connection strings
- update setup controller and view to use separate DB fields
- enable admin to test and save DB settings
- link new DB settings page from admin layout

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684af0ce5dec832cabcef6aa1e88939e