### PR TITLE
Add download file management

### DIFF
--- a/website/MyWebApp/Controllers/FilesController.cs
+++ b/website/MyWebApp/Controllers/FilesController.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+using MyWebApp.Filters;
+using MyWebApp.Models;
+
+namespace MyWebApp.Controllers;
+
+[BasicAuth]
+public class FilesController : Controller
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ILogger<FilesController> _logger;
+
+    public FilesController(ApplicationDbContext context, ILogger<FilesController> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var files = await _context.DownloadFiles.AsNoTracking().ToListAsync();
+        var model = new List<FileStatsViewModel>();
+        foreach (var f in files)
+        {
+            var count = await _context.Downloads.AsNoTracking().CountAsync(d => d.DownloadFileId == f.Id && d.IsSuccessful);
+            model.Add(new FileStatsViewModel { File = f, DownloadCount = count });
+        }
+        return View(model);
+    }
+
+    public IActionResult Create()
+    {
+        return View(new DownloadFile { Created = DateTime.UtcNow });
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(DownloadFile file)
+    {
+        if (ModelState.IsValid)
+        {
+            file.Created = DateTime.UtcNow;
+            _context.DownloadFiles.Add(file);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+        return View(file);
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var file = await _context.DownloadFiles.FindAsync(id);
+        if (file == null) return NotFound();
+        return View(file);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(DownloadFile file)
+    {
+        if (ModelState.IsValid)
+        {
+            _context.Update(file);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+        return View(file);
+    }
+
+    public async Task<IActionResult> Delete(int id)
+    {
+        var file = await _context.DownloadFiles.FindAsync(id);
+        if (file == null) return NotFound();
+        return View(file);
+    }
+
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var file = await _context.DownloadFiles.FindAsync(id);
+        if (file != null)
+        {
+            _context.DownloadFiles.Remove(file);
+            await _context.SaveChangesAsync();
+        }
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -13,6 +13,7 @@ namespace MyWebApp.Data
         // Add DbSet<> properties here
         public DbSet<Recording> Recordings { get; set; }
         public DbSet<Download> Downloads { get; set; }
+        public DbSet<DownloadFile> DownloadFiles { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -23,6 +24,8 @@ namespace MyWebApp.Data
                 .HasIndex(d => d.IsSuccessful);
             modelBuilder.Entity<Download>()
                 .HasIndex(d => d.UserIP);
+            modelBuilder.Entity<DownloadFile>()
+                .HasIndex(f => f.FileName);
         }
     }
 }

--- a/website/MyWebApp/Migrations/20250612164745_AddDownloadFiles.Designer.cs
+++ b/website/MyWebApp/Migrations/20250612164745_AddDownloadFiles.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyWebApp.Data;
 
@@ -10,9 +11,11 @@ using MyWebApp.Data;
 namespace MyWebApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250612164745_AddDownloadFiles")]
+    partial class AddDownloadFiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.5");

--- a/website/MyWebApp/Migrations/20250612164745_AddDownloadFiles.cs
+++ b/website/MyWebApp/Migrations/20250612164745_AddDownloadFiles.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyWebApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDownloadFiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Recordings",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "Recordings",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Recordings",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("Sqlite:Autoincrement", true)
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserIP",
+                table: "Downloads",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserAgent",
+                table: "Downloads",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SessionId",
+                table: "Downloads",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsSuccessful",
+                table: "Downloads",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "bit");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DownloadTime",
+                table: "Downloads",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Country",
+                table: "Downloads",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Downloads",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("Sqlite:Autoincrement", true)
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DownloadFileId",
+                table: "Downloads",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "DownloadFiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    FileName = table.Column<string>(type: "TEXT", nullable: false),
+                    Description = table.Column<string>(type: "TEXT", nullable: false),
+                    Created = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DownloadFiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Downloads_DownloadFileId",
+                table: "Downloads",
+                column: "DownloadFileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Downloads_DownloadTime",
+                table: "Downloads",
+                column: "DownloadTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Downloads_IsSuccessful",
+                table: "Downloads",
+                column: "IsSuccessful");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Downloads_UserIP",
+                table: "Downloads",
+                column: "UserIP");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DownloadFiles_FileName",
+                table: "DownloadFiles",
+                column: "FileName");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Downloads_DownloadFiles_DownloadFileId",
+                table: "Downloads",
+                column: "DownloadFileId",
+                principalTable: "DownloadFiles",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Downloads_DownloadFiles_DownloadFileId",
+                table: "Downloads");
+
+            migrationBuilder.DropTable(
+                name: "DownloadFiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Downloads_DownloadFileId",
+                table: "Downloads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Downloads_DownloadTime",
+                table: "Downloads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Downloads_IsSuccessful",
+                table: "Downloads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Downloads_UserIP",
+                table: "Downloads");
+
+            migrationBuilder.DropColumn(
+                name: "DownloadFileId",
+                table: "Downloads");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Recordings",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "Recordings",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Recordings",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER")
+                .Annotation("Sqlite:Autoincrement", true)
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserIP",
+                table: "Downloads",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserAgent",
+                table: "Downloads",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SessionId",
+                table: "Downloads",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsSuccessful",
+                table: "Downloads",
+                type: "bit",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "INTEGER");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DownloadTime",
+                table: "Downloads",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Country",
+                table: "Downloads",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "Downloads",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER")
+                .Annotation("Sqlite:Autoincrement", true)
+                .OldAnnotation("Sqlite:Autoincrement", true);
+        }
+    }
+}

--- a/website/MyWebApp/Models/AdminModels.cs
+++ b/website/MyWebApp/Models/AdminModels.cs
@@ -33,4 +33,10 @@ namespace MyWebApp.Models
         public string Country { get; set; } = string.Empty;
         public int Count { get; set; }
     }
+
+    public class FileStatsViewModel
+    {
+        public DownloadFile File { get; set; } = new DownloadFile();
+        public int DownloadCount { get; set; }
+    }
 }

--- a/website/MyWebApp/Models/Download.cs
+++ b/website/MyWebApp/Models/Download.cs
@@ -11,5 +11,7 @@ namespace MyWebApp.Models
         public bool IsSuccessful { get; set; }
         public string? SessionId { get; set; }
         public string? Country { get; set; }
+        public int? DownloadFileId { get; set; }
+        public DownloadFile? DownloadFile { get; set; }
     }
 }

--- a/website/MyWebApp/Models/DownloadFile.cs
+++ b/website/MyWebApp/Models/DownloadFile.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyWebApp.Models
+{
+    public class DownloadFile
+    {
+        public int Id { get; set; }
+        public string FileName { get; set; } = string.Empty; // relative path or url
+        public string Description { get; set; } = string.Empty;
+        public DateTime Created { get; set; }
+        public ICollection<Download>? Downloads { get; set; }
+    }
+}

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -21,6 +21,7 @@
                 <a asp-controller="Admin" asp-action="Stats">Stats</a>
                 <a asp-controller="Admin" asp-action="DbSettings">DB Settings</a>
                 <a asp-controller="Admin" asp-action="Logs">Logs</a>
+                <a asp-controller="Files" asp-action="Index">Files</a>
             </nav>
         </div>
     </header>

--- a/website/MyWebApp/Views/Download/Index.cshtml
+++ b/website/MyWebApp/Views/Download/Index.cshtml
@@ -1,14 +1,21 @@
+@model IEnumerable<MyWebApp.Models.DownloadFile>
 @{
     ViewData["Title"] = "Download";
 }
 
-<h1>Download Screen Area Recorder Pro</h1>
+<h1>Downloads</h1>
 
 <p>Total downloads: @ViewBag.TotalDownloads</p>
 
 <form method="post" asp-controller="Download" asp-action="Index" id="download-form">
     <input type="hidden" name="token" id="captcha-token" />
-    <button class="download-btn" type="submit" id="download-btn" disabled>Download Extension</button>
+    <select name="fileId">
+        @foreach (var f in Model)
+        {
+            <option value="@f.Id">@f.FileName - @f.Description</option>
+        }
+    </select>
+    <button class="download-btn" type="submit" id="download-btn" disabled>Download</button>
 </form>
 
 <div class="validation-summary">

--- a/website/MyWebApp/Views/Files/Create.cshtml
+++ b/website/MyWebApp/Views/Files/Create.cshtml
@@ -1,0 +1,17 @@
+@model MyWebApp.Models.DownloadFile
+@{
+    ViewData["Title"] = "Add File";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Add File</h2>
+<form method="post">
+    <div>
+        <label>File Name</label>
+        <input asp-for="FileName" />
+    </div>
+    <div>
+        <label>Description</label>
+        <input asp-for="Description" />
+    </div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/Files/Delete.cshtml
+++ b/website/MyWebApp/Views/Files/Delete.cshtml
@@ -1,0 +1,11 @@
+@model MyWebApp.Models.DownloadFile
+@{
+    ViewData["Title"] = "Delete File";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Delete File</h2>
+<form method="post">
+    <input type="hidden" asp-for="Id" />
+    <p>Are you sure you want to delete @Model.FileName?</p>
+    <button type="submit">Delete</button>
+</form>

--- a/website/MyWebApp/Views/Files/Edit.cshtml
+++ b/website/MyWebApp/Views/Files/Edit.cshtml
@@ -1,0 +1,18 @@
+@model MyWebApp.Models.DownloadFile
+@{
+    ViewData["Title"] = "Edit File";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Edit File</h2>
+<form method="post">
+    <input type="hidden" asp-for="Id" />
+    <div>
+        <label>File Name</label>
+        <input asp-for="FileName" />
+    </div>
+    <div>
+        <label>Description</label>
+        <input asp-for="Description" />
+    </div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/Files/Index.cshtml
+++ b/website/MyWebApp/Views/Files/Index.cshtml
@@ -1,0 +1,24 @@
+@model IEnumerable<MyWebApp.Models.FileStatsViewModel>
+@{
+    ViewData["Title"] = "Files";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Files</h2>
+<p><a asp-action="Create">Add New File</a></p>
+<table class="table table-sm">
+    <thead><tr><th>Name</th><th>Description</th><th>Downloads</th><th></th></tr></thead>
+    <tbody>
+    @foreach(var f in Model)
+    {
+        <tr>
+            <td>@f.File.FileName</td>
+            <td>@f.File.Description</td>
+            <td>@f.DownloadCount</td>
+            <td>
+                <a asp-action="Edit" asp-route-id="@f.File.Id">Edit</a> |
+                <a asp-action="Delete" asp-route-id="@f.File.Id">Delete</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/website/MyWebApp/wwwroot/files/sample.txt
+++ b/website/MyWebApp/wwwroot/files/sample.txt
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- model `DownloadFile` to store hosted files
- track file downloads in `DownloadController`
- admin controller and views to manage files
- show hosted files on download page
- EF migration for new table

## Testing
- `dotnet build website/MyWebApp.sln -c Release`
- `dotnet test website/MyWebApp.sln`


------
https://chatgpt.com/codex/tasks/task_e_684b03e70430832c8c25c31ef9b096ac