### PR TITLE
Replace EF migrations with automatic schema creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,41 +39,20 @@ You can override these values in several ways:
 
 Specify `DatabaseProvider` when switching providers; `Program.cs` will pick the correct `Use*` method automatically.
 
-## Database Migrations
+## Database Initialization
 
-Entity Framework Core migrations are used to create and evolve the database schema. After modifying the `DbContext` or model classes, run the following commands from the `MyWebApp` project directory:
-
-```bash
-# Add a new migration
-dotnet ef migrations add <MigrationName>
-
-# Apply migrations to the configured database
-dotnet ef database update
-```
-
-To generate a SQL script that can be executed manually or on another server, use:
+The schema is created automatically when the application starts using
+`EnsureCreated`. Configure your connection string and provider as described
+above and run:
 
 ```bash
-# Generate a SQL script for all pending migrations
-dotnet ef migrations script > update.sql
+cd website/MyWebApp
+dotnet run
 ```
 
-When the application starts it attempts to connect to the configured database.
-If the connection succeeds, `Program.cs` automatically runs
-`db.Database.Migrate()` to apply any pending migrations. If a connection cannot
-be established, a warning is logged and the app continues to run.
-
-## Deploying Migrations Remotely
-
-1. Build the project and ensure migrations compile.
-2. Copy the generated `update.sql` file to the remote server.
-3. Execute the script using the database's command-line tools (for SQL Server you can use `sqlcmd`):
-
-```bash
-sqlcmd -S <server> -d <database> -i update.sql
-```
-
-This approach avoids installing the .NET SDK on the server while keeping the database schema in sync.
+On first launch the database will be created and indexes added for the selected
+provider. The `/Setup` page lets you test connections or switch providers and
+will recreate the schema if necessary.
 
 ## Running Tests
 

--- a/website/MyWebApp/Controllers/BaseController.cs
+++ b/website/MyWebApp/Controllers/BaseController.cs
@@ -19,6 +19,7 @@ public abstract class BaseController : Controller
     {
         try
         {
+            Db.Database.EnsureCreated();
             return Db.Database.CanConnect();
         }
         catch (Exception ex)

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -26,6 +26,23 @@ namespace MyWebApp.Data
                 .HasIndex(d => d.UserIP);
             modelBuilder.Entity<DownloadFile>()
                 .HasIndex(f => f.FileName);
+            modelBuilder.Entity<Recording>()
+                .HasIndex(r => r.Created);
+
+            // provider specific optimizations
+            var provider = Database.ProviderName ?? string.Empty;
+            if (provider.Contains("Npgsql"))
+            {
+                modelBuilder.Entity<Download>()
+                    .Property(d => d.UserIP)
+                    .HasColumnType("varchar(45)");
+            }
+            else if (provider.Contains("SqlServer"))
+            {
+                modelBuilder.Entity<Download>()
+                    .Property(d => d.UserIP)
+                    .HasColumnType("nvarchar(45)");
+            }
         }
     }
 }

--- a/website/MyWebApp/Views/Setup/Import.cshtml
+++ b/website/MyWebApp/Views/Setup/Import.cshtml
@@ -4,11 +4,11 @@
 
 <h1>Import Data</h1>
 
-<p>Run the following commands from the <code>website/MyWebApp</code> directory to create or update the database schema and import data:</p>
+<p>The database schema is created automatically when the application starts. To ensure the schema exists and seed sample data run:</p>
 
-<pre><code>dotnet ef database update
-sqlcmd -S <server> -d <database> -i update.sql
+<pre><code>cd website/MyWebApp
+dotnet run
 </code></pre>
 
-<p>The <code>update.sql</code> file can be generated using <code>dotnet ef migrations script &gt; update.sql</code>.</p>
+<p>Visit <code>/Setup</code> after startup to test the connection or insert the provided sample data.</p>
 


### PR DESCRIPTION
## Summary
- use `EnsureCreated` in Program startup
- ensure database connection also creates schema
- add provider-specific config in ApplicationDbContext
- update setup controller actions to create schema
- update docs and import instructions

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684b08b1f1e8832c8ee90f0ac324dd5a