### PR TITLE
Add new indexes on Download entity

### DIFF
--- a/website/MyWebApp.Tests/ApplicationDbContextTests.cs
+++ b/website/MyWebApp.Tests/ApplicationDbContextTests.cs
@@ -28,4 +28,25 @@ public class ApplicationDbContextTests
             Assert.Equal("Test", recording.Name);
         }
     }
+
+    [Fact]
+    public void DownloadEntity_HasExpectedIndexes()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase("IndexCheckDb")
+            .Options;
+
+        using var context = new ApplicationDbContext(options);
+        var entity = context.Model.FindEntityType(typeof(Download));
+        Assert.NotNull(entity);
+        var indexPropertySets = entity!.GetIndexes()
+            .Select(i => string.Join(",", i.Properties.Select(p => p.Name)))
+            .ToList();
+
+        Assert.Contains("DownloadTime", indexPropertySets);
+        Assert.Contains("IsSuccessful", indexPropertySets);
+        Assert.Contains("UserIP", indexPropertySets);
+        Assert.Contains("Country", indexPropertySets);
+        Assert.Contains("IsSuccessful,DownloadTime", indexPropertySets);
+    }
 }

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -24,6 +24,10 @@ namespace MyWebApp.Data
                 .HasIndex(d => d.IsSuccessful);
             modelBuilder.Entity<Download>()
                 .HasIndex(d => d.UserIP);
+            modelBuilder.Entity<Download>()
+                .HasIndex(d => d.Country);
+            modelBuilder.Entity<Download>()
+                .HasIndex(d => new { d.IsSuccessful, d.DownloadTime });
             modelBuilder.Entity<DownloadFile>()
                 .HasIndex(f => f.FileName);
             modelBuilder.Entity<Recording>()


### PR DESCRIPTION
## Summary
- extend Download configuration with extra indexes
- verify new index definitions via unit tests

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684bb98c6910832c84506db7d8d6348a