### PR TITLE
Enhance DB configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can override these values in several ways:
 
 Specify `DatabaseProvider` when switching providers; `Program.cs` will pick the correct `Use*` method automatically.
 
+Connection strings built with `ConnectionHelper` add provider-specific optimizations. PostgreSQL enables pooling and prepared statements, SQLite uses a shared cache with WAL mode, and SQL Server configures retries with a 60 second command timeout.
+
 ## Database Initialization
 
 The schema is created automatically when the application starts using

--- a/website/MyWebApp/Models/ConnectionHelper.cs
+++ b/website/MyWebApp/Models/ConnectionHelper.cs
@@ -10,9 +10,9 @@ public static class ConnectionHelper
         {
             case "postgresql":
             case "npgsql":
-                return $"Host={server};Database={database};Username={username};Password={password}";
+                return $"Host={server};Database={database};Username={username};Password={password};Pooling=true;MinPoolSize=1;MaxPoolSize=20;ConnectionIdleLifetime=300;Max Auto Prepare=20;Auto Prepare Min Usages=2";
             case "sqlite":
-                return $"Data Source={database}";
+                return $"Data Source={database};Cache=Shared;Journal Mode=WAL;Synchronous=Normal";
             default:
                 if (string.IsNullOrEmpty(username))
                 {


### PR DESCRIPTION
## Summary
- configure provider-specific defaults in `Program.cs`
- augment `ConnectionHelper` to build optimized connection strings
- document new connection pooling and caching options

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684bbbb2d0d8832c8edcc4ccefd8a64c