### PR TITLE
Add dynamic pages

### DIFF
--- a/website/MyWebApp.Tests/PageTests.cs
+++ b/website/MyWebApp.Tests/PageTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+using MyWebApp.Models;
+using System.Linq;
+using Xunit;
+
+public class PageTests
+{
+    [Fact]
+    public void CanAddAndRetrievePage()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Database.EnsureCreated();
+            context.Pages.Add(new Page { Slug = "test", Title = "Test", BodyHtml = "<p>Hi</p>" });
+            context.SaveChanges();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var page = context.Pages.Single(p => p.Slug == "test");
+            Assert.Equal("Test", page.Title);
+        }
+    }
+}

--- a/website/MyWebApp/Controllers/AdminContentController.cs
+++ b/website/MyWebApp/Controllers/AdminContentController.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+using MyWebApp.Filters;
+using MyWebApp.Models;
+using MyWebApp.Services;
+
+namespace MyWebApp.Controllers;
+
+[BasicAuth]
+public class AdminContentController : Controller
+{
+    private readonly ApplicationDbContext _db;
+    private readonly LayoutService _layout;
+
+    public AdminContentController(ApplicationDbContext db, LayoutService layout)
+    {
+        _db = db;
+        _layout = layout;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var pages = await _db.Pages.AsNoTracking().OrderBy(p => p.Slug).ToListAsync();
+        return View(pages);
+    }
+
+    public IActionResult Create()
+    {
+        return View(new Page());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(Page model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(model);
+        }
+        _db.Pages.Add(model);
+        await _db.SaveChangesAsync();
+        _layout.Reset();
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var page = await _db.Pages.FindAsync(id);
+        if (page == null)
+        {
+            return NotFound();
+        }
+        return View(page);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(Page model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(model);
+        }
+        _db.Update(model);
+        await _db.SaveChangesAsync();
+        _layout.Reset();
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/website/MyWebApp/Controllers/PagesController.cs
+++ b/website/MyWebApp/Controllers/PagesController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+using MyWebApp.Models;
+using MyWebApp.Services;
+
+namespace MyWebApp.Controllers;
+
+public class PagesController : BaseController
+{
+    private readonly LayoutService _layout;
+
+    public PagesController(ApplicationDbContext db, ILogger<PagesController> logger, LayoutService layout)
+        : base(db, logger)
+    {
+        _layout = layout;
+    }
+
+    public async Task<IActionResult> Show(string? slug)
+    {
+        if (!CheckDatabase())
+        {
+            return RedirectToSetup();
+        }
+
+        slug = string.IsNullOrWhiteSpace(slug) ? "home" : slug.ToLowerInvariant();
+        var page = await Db.Pages.AsNoTracking().FirstOrDefaultAsync(p => p.Slug == slug);
+        if (page == null)
+        {
+            return NotFound();
+        }
+
+        ViewBag.HeaderHtml = await _layout.GetHeaderAsync(Db);
+        ViewBag.FooterHtml = await _layout.GetFooterAsync(Db);
+        return View(page);
+    }
+}

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -14,6 +14,7 @@ namespace MyWebApp.Data
         public DbSet<Recording> Recordings { get; set; }
         public DbSet<Download> Downloads { get; set; }
         public DbSet<DownloadFile> DownloadFiles { get; set; }
+        public DbSet<Page> Pages { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -32,6 +33,27 @@ namespace MyWebApp.Data
                 .HasIndex(f => f.FileName);
             modelBuilder.Entity<Recording>()
                 .HasIndex(r => r.Created);
+
+            modelBuilder.Entity<Page>()
+                .HasIndex(p => p.Slug)
+                .IsUnique();
+
+            modelBuilder.Entity<Page>().HasData(
+                new Page
+                {
+                    Id = 1,
+                    Slug = "layout",
+                    Title = "Layout",
+                    HeaderHtml = "<div class=\"container-fluid nav-container\"><a class=\"logo\" href=\"/\">Screen Area Recorder Pro</a><nav class=\"site-nav\"><a href=\"/\">Home</a> <a href=\"/Download\">Download</a> <a href=\"/Home/Faq\">FAQ</a> <a href=\"/Home/Privacy\">Privacy</a> <a href=\"/Setup\">Setup</a></nav></div>",
+                    FooterHtml = "<div class=\"container\">&copy; 2025 - Screen Area Recorder Pro</div>"
+                },
+                new Page
+                {
+                    Id = 2,
+                    Slug = "home",
+                    Title = "Home",
+                    BodyHtml = "<p>Welcome to Screen Area Recorder Pro.</p>"
+                });
 
             // provider specific optimizations
             var provider = Database.ProviderName ?? string.Empty;

--- a/website/MyWebApp/Models/Page.cs
+++ b/website/MyWebApp/Models/Page.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MyWebApp.Models;
+
+public class Page
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(128)]
+    public string Slug { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string Title { get; set; } = string.Empty;
+
+    public string? HeaderHtml { get; set; }
+
+    public string BodyHtml { get; set; } = string.Empty;
+
+    public string? FooterHtml { get; set; }
+}

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -101,6 +101,7 @@ builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();
 builder.Services.AddSession();
 builder.Services.AddSingleton<MyWebApp.Services.CacheService>();
+builder.Services.AddSingleton<MyWebApp.Services.LayoutService>();
 builder.Services.AddScoped<MyWebApp.Services.SchemaValidator>();
 
 var app = builder.Build();
@@ -151,5 +152,10 @@ app.UseAuthorization();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+
+app.MapControllerRoute(
+    name: "pages",
+    pattern: "{*slug}",
+    defaults: new { controller = "Pages", action = "Show" });
 
 app.Run();

--- a/website/MyWebApp/Services/LayoutService.cs
+++ b/website/MyWebApp/Services/LayoutService.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+
+namespace MyWebApp.Services;
+
+public class LayoutService
+{
+    private readonly CacheService _cache;
+    private const string HeaderKey = "layout_header";
+    private const string FooterKey = "layout_footer";
+
+    public LayoutService(CacheService cache)
+    {
+        _cache = cache;
+    }
+
+    public async Task<string> GetHeaderAsync(ApplicationDbContext db)
+    {
+        return await _cache.GetOrCreateAsync(HeaderKey, async e =>
+        {
+            e.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+            return await db.Pages.AsNoTracking()
+                .Where(p => p.Slug == "layout")
+                .Select(p => p.HeaderHtml ?? string.Empty)
+                .FirstOrDefaultAsync() ?? string.Empty;
+        });
+    }
+
+    public async Task<string> GetFooterAsync(ApplicationDbContext db)
+    {
+        return await _cache.GetOrCreateAsync(FooterKey, async e =>
+        {
+            e.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+            return await db.Pages.AsNoTracking()
+                .Where(p => p.Slug == "layout")
+                .Select(p => p.FooterHtml ?? string.Empty)
+                .FirstOrDefaultAsync() ?? string.Empty;
+        });
+    }
+
+    public void Reset()
+    {
+        _cache.Remove(HeaderKey);
+        _cache.Remove(FooterKey);
+    }
+}

--- a/website/MyWebApp/Views/AdminContent/Create.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Create.cshtml
@@ -1,0 +1,14 @@
+@model MyWebApp.Models.Page
+@{
+    ViewData["Title"] = "Create Page";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Create Page</h2>
+<form asp-action="Create" method="post">
+    <div><label>Slug</label><input asp-for="Slug" /></div>
+    <div><label>Title</label><input asp-for="Title" /></div>
+    <div><label>Header</label><textarea asp-for="HeaderHtml"></textarea></div>
+    <div><label>Body</label><textarea asp-for="BodyHtml"></textarea></div>
+    <div><label>Footer</label><textarea asp-for="FooterHtml"></textarea></div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/AdminContent/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Edit.cshtml
@@ -1,0 +1,15 @@
+@model MyWebApp.Models.Page
+@{
+    ViewData["Title"] = "Edit Page";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Edit Page</h2>
+<form asp-action="Edit" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div><label>Slug</label><input asp-for="Slug" /></div>
+    <div><label>Title</label><input asp-for="Title" /></div>
+    <div><label>Header</label><textarea asp-for="HeaderHtml"></textarea></div>
+    <div><label>Body</label><textarea asp-for="BodyHtml"></textarea></div>
+    <div><label>Footer</label><textarea asp-for="FooterHtml"></textarea></div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/AdminContent/Index.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Index.cshtml
@@ -1,0 +1,22 @@
+@model IEnumerable<MyWebApp.Models.Page>
+@{
+    ViewData["Title"] = "Pages";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Pages</h2>
+<p><a asp-action="Create">Create New</a></p>
+<table>
+    <thead>
+        <tr><th>Slug</th><th>Title</th><th></th></tr>
+    </thead>
+    <tbody>
+@foreach (var p in Model)
+{
+    <tr>
+        <td>@p.Slug</td>
+        <td>@p.Title</td>
+        <td><a asp-action="Edit" asp-route-id="@p.Id">Edit</a></td>
+    </tr>
+}
+    </tbody>
+</table>

--- a/website/MyWebApp/Views/Pages/Show.cshtml
+++ b/website/MyWebApp/Views/Pages/Show.cshtml
@@ -1,0 +1,5 @@
+@model MyWebApp.Models.Page
+@{
+    ViewData["Title"] = Model.Title;
+}
+@Html.Raw(Model.BodyHtml)

--- a/website/MyWebApp/Views/Shared/_Layout.cshtml
+++ b/website/MyWebApp/Views/Shared/_Layout.cshtml
@@ -6,19 +6,17 @@
     <title>@ViewData["Title"] - Screen Area Recorder Pro</title>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
+@using MyWebApp.Services
+@using MyWebApp.Data
+@inject LayoutService LayoutService
+@inject ApplicationDbContext Db
+@{
+    var headerHtml = ViewBag.HeaderHtml as string ?? await LayoutService.GetHeaderAsync(Db);
+    var footerHtml = ViewBag.FooterHtml as string ?? await LayoutService.GetFooterAsync(Db);
+}
 <body>
     <header class="site-header">
-        <div class="container-fluid nav-container">
-            <a class="logo" asp-area="" asp-controller="Home" asp-action="Index">Screen Area Recorder Pro</a>
-            <nav class="site-nav">
-                <a asp-area="" asp-controller="Home" asp-action="Index">Home</a>
-                <a asp-area="" asp-controller="Download" asp-action="Index">Download</a>
-                <a asp-area="" asp-controller="Home" asp-action="Faq">FAQ</a>
-                <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                <a asp-area="" asp-controller="Setup" asp-action="Index">Setup</a>
-                @if (User?.Identity?.IsAuthenticated == true) { <a asp-controller="Admin" asp-action="Index">Admin</a> }
-            </nav>
-        </div>
+        @Html.Raw(headerHtml)
     </header>
     <div class="container">
         <main role="main" class="pb-3">
@@ -27,9 +25,7 @@
     </div>
 
     <footer class="site-footer">
-        <div class="container">
-            &copy; 2025 - Screen Area Recorder Pro
-        </div>
+        @Html.Raw(footerHtml)
     </footer>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)


### PR DESCRIPTION
## Summary
- support editable pages via new `Page` model and default seed data
- add layout service for header/footer from database
- implement page display and admin CRUD controllers
- load header/footer dynamically in layout
- wire up flexible routing for page slugs
- include tests for the new `Page` entity

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684c18a2f9d4832c9f456ad6174e1a75