### PR TITLE
Apply security hotfixes

### DIFF
--- a/website/MyWebApp.Tests/BasicAuthAttributeTests.cs
+++ b/website/MyWebApp.Tests/BasicAuthAttributeTests.cs
@@ -5,6 +5,9 @@ using MyWebApp.Filters;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using MyWebApp.Options;
 using Xunit;
 
 public class BasicAuthAttributeTests
@@ -13,7 +16,12 @@ public class BasicAuthAttributeTests
     public void NoHeader_ReturnsUnauthorized()
     {
         var attr = new BasicAuthAttribute();
-        var http = new DefaultHttpContext();
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.Configure<MyWebApp.Options.AdminAuthOptions>(o => { o.Username = "admin"; o.Password = "SecurePass123"; });
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string,string?> { {"AdminAuth:Username","admin"}, {"AdminAuth:Password","SecurePass123"} }).Build());
+        var provider = services.BuildServiceProvider();
+        var http = new DefaultHttpContext { RequestServices = provider };
         var ctx = new AuthorizationFilterContext(
             new ActionContext(http, new Microsoft.AspNetCore.Routing.RouteData(), new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()),
             new List<IFilterMetadata>());
@@ -25,7 +33,12 @@ public class BasicAuthAttributeTests
     public void ValidHeader_AllowsAccess()
     {
         var attr = new BasicAuthAttribute();
-        var http = new DefaultHttpContext();
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.Configure<MyWebApp.Options.AdminAuthOptions>(o => { o.Username = "admin"; o.Password = "SecurePass123"; });
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string,string?> { {"AdminAuth:Username","admin"}, {"AdminAuth:Password","SecurePass123"} }).Build());
+        var provider = services.BuildServiceProvider();
+        var http = new DefaultHttpContext { RequestServices = provider };
         var creds = Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:SecurePass123"));
         http.Request.Headers["Authorization"] = "Basic " + creds;
         var ctx = new AuthorizationFilterContext(
@@ -34,5 +47,37 @@ public class BasicAuthAttributeTests
         attr.OnAuthorization(ctx);
         Assert.Null(ctx.Result);
         Assert.Equal("admin", ctx.HttpContext.User.Identity?.Name);
+    }
+
+    [Fact]
+    public void WrongHeader_ReturnsUnauthorized()
+    {
+        var attr = new BasicAuthAttribute();
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.Configure<MyWebApp.Options.AdminAuthOptions>(o => { o.Username = "admin"; o.Password = "SecurePass123"; });
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string,string?> { {"AdminAuth:Username","admin"}, {"AdminAuth:Password","SecurePass123"} }).Build());
+        var provider = services.BuildServiceProvider();
+        var http = new DefaultHttpContext { RequestServices = provider };
+        var creds = Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:wrong"));
+        http.Request.Headers["Authorization"] = "Basic " + creds;
+        var ctx = new AuthorizationFilterContext(
+            new ActionContext(http, new Microsoft.AspNetCore.Routing.RouteData(), new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()),
+            new List<IFilterMetadata>());
+        attr.OnAuthorization(ctx);
+        Assert.IsType<UnauthorizedResult>(ctx.Result);
+    }
+
+    [Fact]
+    public void MissingConfig_Throws()
+    {
+        var attr = new BasicAuthAttribute();
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        var provider = services.BuildServiceProvider();
+        var http = new DefaultHttpContext { RequestServices = provider };
+        var ctx = new AuthorizationFilterContext(
+            new ActionContext(http, new Microsoft.AspNetCore.Routing.RouteData(), new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()),
+            new List<IFilterMetadata>());
+        Assert.Throws<InvalidOperationException>(() => attr.OnAuthorization(ctx));
     }
 }

--- a/website/MyWebApp.Tests/DownloadControllerTests.cs
+++ b/website/MyWebApp.Tests/DownloadControllerTests.cs
@@ -2,7 +2,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using MyWebApp.Options;
 using Microsoft.Extensions.Logging.Abstractions;
 using MyWebApp.Controllers;
 using MyWebApp.Data;
@@ -31,15 +32,15 @@ public class DownloadControllerTests
     {
         conn = new SqliteConnection("DataSource=:memory:");
         conn.Open();
-        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+        var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseSqlite(conn)
             .Options;
-        var ctx = new ApplicationDbContext(options);
+        var ctx = new ApplicationDbContext(dbOptions);
         ctx.Database.EnsureCreated();
         var memory = new MemoryCache(new MemoryCacheOptions());
         var cache = new CacheService(memory);
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["Captcha:SiteKey"] = "k" }).Build();
-        var controller = new DownloadController(ctx, NullLogger<DownloadController>.Instance, memory, cache, new FakeHttpClientFactory(), config);
+        var captcha = Microsoft.Extensions.Options.Options.Create(new MyWebApp.Options.CaptchaOptions { SiteKey = "k" });
+        var controller = new DownloadController(ctx, NullLogger<DownloadController>.Instance, memory, cache, new FakeHttpClientFactory(), captcha);
         controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { Session = new DummySession() } };
         return (controller, ctx);
     }

--- a/website/MyWebApp/Controllers/AdminController.cs
+++ b/website/MyWebApp/Controllers/AdminController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using System.Data.Common;
 using MyWebApp.Data;
 using MyWebApp.Filters;
 using MyWebApp.Models;
@@ -41,7 +42,7 @@ namespace MyWebApp.Controllers
             {
                 return _context.Database.CanConnect();
             }
-            catch (Exception ex)
+            catch (System.Data.Common.DbException ex)
             {
                 _logger.LogError(ex, "Database connectivity check failed");
                 return false;
@@ -200,7 +201,11 @@ namespace MyWebApp.Controllers
                 using var testDb = new ApplicationDbContext(optionsBuilder.Options);
                 TempData["SetupResult"] = testDb.Database.CanConnect() ? "Connection successful" : "Connection failed";
             }
-            catch (Exception ex)
+            catch (System.Data.Common.DbException ex)
+            {
+                TempData["SetupResult"] = "Connection failed: " + ex.Message;
+            }
+            catch (InvalidOperationException ex)
             {
                 TempData["SetupResult"] = "Connection failed: " + ex.Message;
             }
@@ -236,7 +241,15 @@ namespace MyWebApp.Controllers
 
                 TempData["SetupResult"] = "Configuration saved.";
             }
-            catch (Exception ex)
+            catch (System.IO.IOException ex)
+            {
+                TempData["SetupResult"] = "Save failed: " + ex.Message;
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                TempData["SetupResult"] = "Save failed: " + ex.Message;
+            }
+            catch (UnauthorizedAccessException ex)
             {
                 TempData["SetupResult"] = "Save failed: " + ex.Message;
             }

--- a/website/MyWebApp/Controllers/HomeController.cs
+++ b/website/MyWebApp/Controllers/HomeController.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using MyWebApp.Models;
 using MyWebApp.Services;
+using Microsoft.EntityFrameworkCore;
 
 namespace MyWebApp.Controllers;
 
@@ -28,7 +29,7 @@ public class HomeController : BaseController
         {
             Db.SaveChanges();
         }
-        catch (Exception ex)
+        catch (DbUpdateException ex)
         {
             return RedirectToSetup(ex);
         }

--- a/website/MyWebApp/Controllers/SetupController.cs
+++ b/website/MyWebApp/Controllers/SetupController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using MyWebApp.Services;
+using System.Data.Common;
 
 namespace MyWebApp.Controllers;
 
@@ -93,7 +94,11 @@ public class SetupController : BaseController
             }
             TempData["SetupResult"] = connected ? "Connection successful" : "Connection failed";
         }
-        catch (Exception ex)
+        catch (System.Data.Common.DbException ex)
+        {
+            TempData["SetupResult"] = "Connection failed: " + ex.Message;
+        }
+        catch (InvalidOperationException ex)
         {
             TempData["SetupResult"] = "Connection failed: " + ex.Message;
         }
@@ -146,7 +151,15 @@ public class SetupController : BaseController
             context.Database.EnsureCreated();
             TempData["SetupResult"] = "Configuration saved.";
         }
-        catch (Exception ex)
+        catch (System.IO.IOException ex)
+        {
+            TempData["SetupResult"] = "Save failed: " + ex.Message;
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            TempData["SetupResult"] = "Save failed: " + ex.Message;
+        }
+        catch (System.Data.Common.DbException ex)
         {
             TempData["SetupResult"] = "Save failed: " + ex.Message;
         }
@@ -181,7 +194,7 @@ public class SetupController : BaseController
             Db.SaveChanges();
             TempData["SetupResult"] = "Sample data inserted.";
         }
-        catch (Exception ex)
+        catch (DbUpdateException ex)
         {
             TempData["SetupResult"] = "Seeding failed: " + ex.Message;
         }

--- a/website/MyWebApp/Options/AdminAuthOptions.cs
+++ b/website/MyWebApp/Options/AdminAuthOptions.cs
@@ -1,0 +1,8 @@
+namespace MyWebApp.Options
+{
+    public class AdminAuthOptions
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/website/MyWebApp/Options/CaptchaOptions.cs
+++ b/website/MyWebApp/Options/CaptchaOptions.cs
@@ -1,0 +1,9 @@
+namespace MyWebApp.Options
+{
+    public class CaptchaOptions
+    {
+        public string SiteKey { get; set; } = string.Empty;
+        public string SecretKey { get; set; } = string.Empty;
+        public string VerifyUrl { get; set; } = string.Empty;
+    }
+}

--- a/website/MyWebApp/appsettings.json
+++ b/website/MyWebApp/appsettings.json
@@ -11,8 +11,12 @@
   },
   "DatabaseProvider": "SqlServer",
   "Captcha": {
-    "SiteKey": "YOUR_SITE_KEY",
-    "SecretKey": "YOUR_SECRET_KEY",
+    "SiteKey": "${CAPTCHA_SITE_KEY}",
+    "SecretKey": "${CAPTCHA_SECRET_KEY}",
     "VerifyUrl": "https://www.google.com/recaptcha/api/siteverify"
+  },
+  "AdminAuth": {
+    "Username": "",
+    "Password": ""
   }
 }


### PR DESCRIPTION
## Summary
- implement `AdminAuthOptions` and `CaptchaOptions`
- load configuration for `BasicAuthAttribute` and validate
- fail-fast on missing admin auth config at startup
- use typed captcha options in `DownloadController`
- replace broad exception catches with specific ones
- update unit tests for new behaviour

## Testing
- `dotnet build MyWebApp.sln`
- `dotnet test MyWebApp.sln`


------
https://chatgpt.com/codex/tasks/task_e_684c238c8fe8832c98c020304c28f905