### PR TITLE
Persist admin credentials in DB

### DIFF
--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -15,6 +15,7 @@ namespace MyWebApp.Data
         public DbSet<Download> Downloads { get; set; }
         public DbSet<DownloadFile> DownloadFiles { get; set; }
         public DbSet<Page> Pages { get; set; }
+        public DbSet<AdminCredential> AdminCredentials { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/website/MyWebApp/Models/AdminCredential.cs
+++ b/website/MyWebApp/Models/AdminCredential.cs
@@ -1,0 +1,8 @@
+namespace MyWebApp.Models;
+
+public class AdminCredential
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add `AdminCredential` model
- register `AdminCredentials` DbSet
- load and seed admin credentials from the database with defaults

## Testing
- `dotnet test MyWebApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d047b6cd4832c8c330d8ba4b98087