### PR TITLE
Implement log viewer and CMS page deletion

### DIFF
--- a/website/MyWebApp/Controllers/AdminContentController.cs
+++ b/website/MyWebApp/Controllers/AdminContentController.cs
@@ -67,4 +67,28 @@ public class AdminContentController : Controller
         _layout.Reset();
         return RedirectToAction(nameof(Index));
     }
+
+    public async Task<IActionResult> Delete(int id)
+    {
+        var page = await _db.Pages.FindAsync(id);
+        if (page == null)
+        {
+            return NotFound();
+        }
+        return View(page);
+    }
+
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var page = await _db.Pages.FindAsync(id);
+        if (page != null)
+        {
+            _db.Pages.Remove(page);
+            await _db.SaveChangesAsync();
+            _layout.Reset();
+        }
+        return RedirectToAction(nameof(Index));
+    }
 }

--- a/website/MyWebApp/Controllers/AdminController.cs
+++ b/website/MyWebApp/Controllers/AdminController.cs
@@ -258,7 +258,24 @@ namespace MyWebApp.Controllers
 
         public IActionResult Logs()
         {
-            // For demo purposes, logs are not implemented
+            var logPath = Path.Combine(_env.ContentRootPath, "Logs", "app.log");
+            string[] lines = Array.Empty<string>();
+            if (System.IO.File.Exists(logPath))
+            {
+                try
+                {
+                    lines = System.IO.File.ReadLines(logPath)
+                        .Reverse()
+                        .Take(200)
+                        .Reverse()
+                        .ToArray();
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogError(ex, "Failed to read log file");
+                }
+            }
+            ViewBag.LogLines = lines;
             return View();
         }
 

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -9,9 +9,14 @@ using Npgsql.EntityFrameworkCore.PostgreSQL;
 using Microsoft.Extensions.Options;
 using System.Linq;
 using System;
+using System.IO;
 
 var builder = WebApplication.CreateBuilder(args);
 var startupLogger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger("Startup");
+
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
+builder.Logging.AddProvider(new FileLoggerProvider(Path.Combine(builder.Environment.ContentRootPath, "Logs", "app.log")));
 
 // Allow connection string overrides from environment-specific files,
 // environment variables, and command-line arguments

--- a/website/MyWebApp/Services/FileLoggerProvider.cs
+++ b/website/MyWebApp/Services/FileLoggerProvider.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace MyWebApp.Services;
+
+public class FileLoggerProvider : ILoggerProvider
+{
+    private readonly string _filePath;
+    private readonly ConcurrentDictionary<string, FileLogger> _loggers = new();
+
+    public FileLoggerProvider(string filePath)
+    {
+        _filePath = filePath;
+        Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, name => new FileLogger(_filePath, name));
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+public class FileLogger : ILogger
+{
+    private readonly string _filePath;
+    private readonly string _category;
+    private static readonly object _lock = new();
+
+    public FileLogger(string filePath, string category)
+    {
+        _filePath = filePath;
+        _category = category;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (formatter == null) return;
+        var message = $"{DateTime.UtcNow:u} [{logLevel}] {_category}: {formatter(state, exception)}";
+        if (exception != null) message += $"\n{exception}";
+        lock (_lock)
+        {
+            File.AppendAllText(_filePath, message + Environment.NewLine);
+        }
+    }
+
+    private class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+        public void Dispose() { }
+    }
+}

--- a/website/MyWebApp/Views/Admin/Logs.cshtml
+++ b/website/MyWebApp/Views/Admin/Logs.cshtml
@@ -3,4 +3,13 @@
     ViewData["Title"] = "Logs";
 }
 <h2>Logs</h2>
-<p>Log viewing not implemented.</p>
+@if (ViewBag.LogLines == null || ((string[])ViewBag.LogLines).Length == 0)
+{
+    <p>No log entries found.</p>
+}
+else
+{
+    <pre class="log-box">
+@string.Join("\n", (string[])ViewBag.LogLines)
+    </pre>
+}

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -22,6 +22,7 @@
                 <a asp-controller="Admin" asp-action="DbSettings">DB Settings</a>
                 <a asp-controller="Admin" asp-action="Logs">Logs</a>
                 <a asp-controller="Files" asp-action="Index">Files</a>
+                <a asp-controller="AdminContent" asp-action="Index">Pages</a>
                 <a asp-controller="Account" asp-action="Logout">Logout</a>
             </nav>
         </div>

--- a/website/MyWebApp/Views/AdminContent/Delete.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Delete.cshtml
@@ -1,0 +1,12 @@
+@model MyWebApp.Models.Page
+@{
+    ViewData["Title"] = "Delete Page";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Delete Page</h2>
+<form asp-action="Delete" method="post">
+    <input type="hidden" asp-for="Id" />
+    <p>Are you sure you want to delete <strong>@Model.Title</strong>?</p>
+    <button type="submit">Delete</button>
+    <a asp-action="Index">Cancel</a>
+</form>

--- a/website/MyWebApp/Views/AdminContent/Index.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Index.cshtml
@@ -7,7 +7,7 @@
 <p><a asp-action="Create">Create New</a></p>
 <table>
     <thead>
-        <tr><th>Slug</th><th>Title</th><th></th></tr>
+        <tr><th>Slug</th><th>Title</th><th colspan="2"></th></tr>
     </thead>
     <tbody>
 @foreach (var p in Model)
@@ -16,6 +16,7 @@
         <td>@p.Slug</td>
         <td>@p.Title</td>
         <td><a asp-action="Edit" asp-route-id="@p.Id">Edit</a></td>
+        <td><a asp-action="Delete" asp-route-id="@p.Id">Delete</a></td>
     </tr>
 }
     </tbody>

--- a/website/MyWebApp/wwwroot/css/admin.css
+++ b/website/MyWebApp/wwwroot/css/admin.css
@@ -19,6 +19,16 @@ body {
     padding: 1rem;
     border-radius: 4px;
 }
+.log-box {
+    background: #111;
+    padding: 1rem;
+    border-radius: 4px;
+    max-height: 400px;
+    overflow: auto;
+    white-space: pre-wrap;
+    font-family: monospace;
+    border: 1px solid #444;
+}
 .pagination a, .pagination span {
     margin-right: 0.25rem;
 }


### PR DESCRIPTION
## Summary
- add simple file logger provider and hook it in Program.cs
- implement log viewer in Admin area
- enable CMS page deletion with confirm view
- add admin menu link for managing pages
- style log viewer

## Testing
- `dotnet test MyWebApp.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684d2f9b9b14832ca45386754643a94d