### PR TITLE
Add Quill editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ cd website
 dotnet restore MyWebApp.sln
 libman restore
 ```
+`libman restore` downloads client-side libraries, including the Quill editor
+used on the admin content pages.
 
 ## Configuring the Database Connection
 

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -9,7 +9,9 @@
     <title>Admin - Screen Area Recorder Pro</title>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/admin.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/lib/quill/dist/quill.snow.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="~/lib/quill/dist/quill.min.js"></script>
 </head>
 <body>
     <header class="site-header admin-header">

--- a/website/MyWebApp/Views/AdminContent/Create.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Create.cshtml
@@ -7,8 +7,33 @@
 <form asp-action="Create" method="post">
     <div><label>Slug</label><input asp-for="Slug" /></div>
     <div><label>Title</label><input asp-for="Title" /></div>
-    <div><label>Header</label><textarea asp-for="HeaderHtml"></textarea></div>
-    <div><label>Body</label><textarea asp-for="BodyHtml"></textarea></div>
-    <div><label>Footer</label><textarea asp-for="FooterHtml"></textarea></div>
+    <div>
+        <label>Header</label>
+        <div id="header-editor" class="quill-editor"></div>
+        <input type="hidden" asp-for="HeaderHtml" />
+    </div>
+    <div>
+        <label>Body</label>
+        <div id="body-editor" class="quill-editor"></div>
+        <input type="hidden" asp-for="BodyHtml" />
+    </div>
+    <div>
+        <label>Footer</label>
+        <div id="footer-editor" class="quill-editor"></div>
+        <input type="hidden" asp-for="FooterHtml" />
+    </div>
     <button type="submit">Save</button>
 </form>
+<script>
+    const headerQuill = new Quill('#header-editor', { theme: 'snow' });
+    const bodyQuill = new Quill('#body-editor', { theme: 'snow' });
+    const footerQuill = new Quill('#footer-editor', { theme: 'snow' });
+    headerQuill.root.innerHTML = document.getElementById('HeaderHtml').value;
+    bodyQuill.root.innerHTML = document.getElementById('BodyHtml').value;
+    footerQuill.root.innerHTML = document.getElementById('FooterHtml').value;
+    document.querySelector('form').addEventListener('submit', function () {
+        document.getElementById('HeaderHtml').value = headerQuill.root.innerHTML;
+        document.getElementById('BodyHtml').value = bodyQuill.root.innerHTML;
+        document.getElementById('FooterHtml').value = footerQuill.root.innerHTML;
+    });
+</script>

--- a/website/MyWebApp/Views/AdminContent/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Edit.cshtml
@@ -8,8 +8,33 @@
     <input type="hidden" asp-for="Id" />
     <div><label>Slug</label><input asp-for="Slug" /></div>
     <div><label>Title</label><input asp-for="Title" /></div>
-    <div><label>Header</label><textarea asp-for="HeaderHtml"></textarea></div>
-    <div><label>Body</label><textarea asp-for="BodyHtml"></textarea></div>
-    <div><label>Footer</label><textarea asp-for="FooterHtml"></textarea></div>
+    <div>
+        <label>Header</label>
+        <div id="header-editor" class="quill-editor"></div>
+        <input type="hidden" asp-for="HeaderHtml" />
+    </div>
+    <div>
+        <label>Body</label>
+        <div id="body-editor" class="quill-editor"></div>
+        <input type="hidden" asp-for="BodyHtml" />
+    </div>
+    <div>
+        <label>Footer</label>
+        <div id="footer-editor" class="quill-editor"></div>
+        <input type="hidden" asp-for="FooterHtml" />
+    </div>
     <button type="submit">Save</button>
 </form>
+<script>
+    const headerQuill = new Quill('#header-editor', { theme: 'snow' });
+    const bodyQuill = new Quill('#body-editor', { theme: 'snow' });
+    const footerQuill = new Quill('#footer-editor', { theme: 'snow' });
+    headerQuill.root.innerHTML = document.getElementById('HeaderHtml').value;
+    bodyQuill.root.innerHTML = document.getElementById('BodyHtml').value;
+    footerQuill.root.innerHTML = document.getElementById('FooterHtml').value;
+    document.querySelector('form').addEventListener('submit', function () {
+        document.getElementById('HeaderHtml').value = headerQuill.root.innerHTML;
+        document.getElementById('BodyHtml').value = bodyQuill.root.innerHTML;
+        document.getElementById('FooterHtml').value = footerQuill.root.innerHTML;
+    });
+</script>

--- a/website/MyWebApp/libman.json
+++ b/website/MyWebApp/libman.json
@@ -9,6 +9,10 @@
     {
       "library": "jquery@3.7.1",
       "destination": "wwwroot/lib/jquery/"
+    },
+    {
+      "library": "quill@1.3.7",
+      "destination": "wwwroot/lib/quill/"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- fetch Quill via libman
- load Quill assets on admin layout
- use Quill editors on page content forms
- document that libman downloads the editor

## Testing
- `libman restore` *(fails: library could not be resolved)*
- `dotnet test website/MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684d985fe280832cb7765788a070252f