### PR TITLE
Add PageSection model and admin features

### DIFF
--- a/website/MyWebApp.Tests/PageSectionTests.cs
+++ b/website/MyWebApp.Tests/PageSectionTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+using MyWebApp.Models;
+using Xunit;
+
+public class PageSectionTests
+{
+    [Fact]
+    public void CanAddAndRetrievePageSection()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Database.EnsureCreated();
+            var page = new Page { Slug = "test", Title = "Test" };
+            context.Pages.Add(page);
+            context.SaveChanges();
+            context.PageSections.Add(new PageSection { PageId = page.Id, Area = "header", Html = "<p>hi</p>" });
+            context.SaveChanges();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var section = context.PageSections.Include(s => s.Page)
+                .Single(s => s.Area == "header" && s.Page!.Slug == "test");
+            Assert.Equal("<p>hi</p>", section.Html);
+            Assert.Equal("test", section.Page!.Slug);
+        }
+    }
+}

--- a/website/MyWebApp/Controllers/AdminPageSectionController.cs
+++ b/website/MyWebApp/Controllers/AdminPageSectionController.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using MyWebApp.Data;
+using MyWebApp.Filters;
+using MyWebApp.Models;
+using MyWebApp.Services;
+
+namespace MyWebApp.Controllers;
+
+[BasicAuth]
+public class AdminPageSectionController : Controller
+{
+    private readonly ApplicationDbContext _db;
+    private readonly LayoutService _layout;
+
+    public AdminPageSectionController(ApplicationDbContext db, LayoutService layout)
+    {
+        _db = db;
+        _layout = layout;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var sections = await _db.PageSections.AsNoTracking()
+            .Include(s => s.Page)
+            .OrderBy(s => s.Page.Slug).ThenBy(s => s.Area)
+            .ToListAsync();
+        return View(sections);
+    }
+
+    private async Task LoadPagesAsync()
+    {
+        ViewBag.Pages = await _db.Pages.AsNoTracking().OrderBy(p => p.Slug).ToListAsync();
+    }
+
+    public async Task<IActionResult> Create()
+    {
+        await LoadPagesAsync();
+        return View(new PageSection());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(PageSection model)
+    {
+        if (!ModelState.IsValid)
+        {
+            await LoadPagesAsync();
+            return View(model);
+        }
+        _db.PageSections.Add(model);
+        await _db.SaveChangesAsync();
+        _layout.Reset();
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var section = await _db.PageSections.FindAsync(id);
+        if (section == null) return NotFound();
+        await LoadPagesAsync();
+        return View(section);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(PageSection model)
+    {
+        if (!ModelState.IsValid)
+        {
+            await LoadPagesAsync();
+            return View(model);
+        }
+        _db.Update(model);
+        await _db.SaveChangesAsync();
+        _layout.Reset();
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Delete(int id)
+    {
+        var section = await _db.PageSections.FindAsync(id);
+        if (section == null) return NotFound();
+        return View(section);
+    }
+
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var section = await _db.PageSections.FindAsync(id);
+        if (section != null)
+        {
+            _db.PageSections.Remove(section);
+            await _db.SaveChangesAsync();
+            _layout.Reset();
+        }
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/website/MyWebApp/Controllers/PagesController.cs
+++ b/website/MyWebApp/Controllers/PagesController.cs
@@ -30,8 +30,18 @@ public class PagesController : BaseController
             return NotFound();
         }
 
-        ViewBag.HeaderHtml = await _layout.GetHeaderAsync(Db);
-        ViewBag.FooterHtml = await _layout.GetFooterAsync(Db);
+        var header = await _layout.GetSectionAsync(Db, page.Id, "header");
+        if (string.IsNullOrEmpty(header))
+        {
+            header = await _layout.GetHeaderAsync(Db);
+        }
+        var footer = await _layout.GetSectionAsync(Db, page.Id, "footer");
+        if (string.IsNullOrEmpty(footer))
+        {
+            footer = await _layout.GetFooterAsync(Db);
+        }
+        ViewBag.HeaderHtml = header;
+        ViewBag.FooterHtml = footer;
         return View(page);
     }
 }

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -15,6 +15,7 @@ namespace MyWebApp.Data
         public DbSet<Download> Downloads { get; set; }
         public DbSet<DownloadFile> DownloadFiles { get; set; }
         public DbSet<Page> Pages { get; set; }
+        public DbSet<PageSection> PageSections { get; set; }
         public DbSet<AdminCredential> AdminCredentials { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -39,6 +40,10 @@ namespace MyWebApp.Data
                 .HasIndex(p => p.Slug)
                 .IsUnique();
 
+            modelBuilder.Entity<PageSection>()
+                .HasIndex(s => new { s.PageId, s.Area })
+                .IsUnique();
+
             modelBuilder.Entity<Page>().HasData(
                 new Page
                 {
@@ -54,6 +59,22 @@ namespace MyWebApp.Data
                     Slug = "home",
                     Title = "Home",
                     BodyHtml = "<p>Welcome to Screen Area Recorder Pro.</p>"
+                });
+
+            modelBuilder.Entity<PageSection>().HasData(
+                new PageSection
+                {
+                    Id = 1,
+                    PageId = 1,
+                    Area = "header",
+                    Html = "<div class=\"container-fluid nav-container\"><a class=\"logo\" href=\"/\">Screen Area Recorder Pro</a><nav class=\"site-nav\"><a href=\"/\">Home</a> <a href=\"/Download\">Download</a> <a href=\"/Home/Faq\">FAQ</a> <a href=\"/Home/Privacy\">Privacy</a> <a href=\"/Setup\">Setup</a> <a href=\"/Account/Login\">Login</a></nav></div>"
+                },
+                new PageSection
+                {
+                    Id = 2,
+                    PageId = 1,
+                    Area = "footer",
+                    Html = "<div class=\"container\">&copy; 2025 - Screen Area Recorder Pro</div>"
                 });
 
             // provider specific optimizations

--- a/website/MyWebApp/Models/PageSection.cs
+++ b/website/MyWebApp/Models/PageSection.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MyWebApp.Models;
+
+public class PageSection
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int PageId { get; set; }
+
+    [Required]
+    [MaxLength(64)]
+    public string Area { get; set; } = string.Empty;
+
+    public string Html { get; set; } = string.Empty;
+
+    public Page? Page { get; set; }
+}

--- a/website/MyWebApp/Services/LayoutService.cs
+++ b/website/MyWebApp/Services/LayoutService.cs
@@ -19,9 +19,9 @@ public class LayoutService
         return await _cache.GetOrCreateAsync(HeaderKey, async e =>
         {
             e.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
-            return await db.Pages.AsNoTracking()
-                .Where(p => p.Slug == "layout")
-                .Select(p => p.HeaderHtml ?? string.Empty)
+            return await db.PageSections.AsNoTracking()
+                .Where(s => s.Page.Slug == "layout" && s.Area == "header")
+                .Select(s => s.Html)
                 .FirstOrDefaultAsync() ?? string.Empty;
         });
     }
@@ -31,11 +31,19 @@ public class LayoutService
         return await _cache.GetOrCreateAsync(FooterKey, async e =>
         {
             e.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
-            return await db.Pages.AsNoTracking()
-                .Where(p => p.Slug == "layout")
-                .Select(p => p.FooterHtml ?? string.Empty)
+            return await db.PageSections.AsNoTracking()
+                .Where(s => s.Page.Slug == "layout" && s.Area == "footer")
+                .Select(s => s.Html)
                 .FirstOrDefaultAsync() ?? string.Empty;
         });
+    }
+
+    public async Task<string> GetSectionAsync(ApplicationDbContext db, int pageId, string area)
+    {
+        return await db.PageSections.AsNoTracking()
+            .Where(s => s.PageId == pageId && s.Area == area)
+            .Select(s => s.Html)
+            .FirstOrDefaultAsync() ?? string.Empty;
     }
 
     public void Reset()

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -23,6 +23,7 @@
                 <a asp-controller="Admin" asp-action="Logs">Logs</a>
                 <a asp-controller="Files" asp-action="Index">Files</a>
                 <a asp-controller="AdminContent" asp-action="Index">Pages</a>
+                <a asp-controller="AdminPageSection" asp-action="Index">Sections</a>
                 <a asp-controller="Account" asp-action="Logout">Logout</a>
             </nav>
         </div>

--- a/website/MyWebApp/Views/AdminPageSection/Create.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Create.cshtml
@@ -1,0 +1,22 @@
+@model MyWebApp.Models.PageSection
+@{
+    ViewData["Title"] = "Create Section";
+    Layout = "../Admin/_AdminLayout";
+    var pages = ViewBag.Pages as List<MyWebApp.Models.Page>;
+}
+<h2>Create Section</h2>
+<form asp-action="Create" method="post">
+    <div>
+        <label>Page</label>
+        <select asp-for="PageId" asp-items="@(new SelectList(pages, "Id", "Slug"))"></select>
+    </div>
+    <div>
+        <label>Area</label>
+        <input asp-for="Area" />
+    </div>
+    <div>
+        <label>Html</label>
+        <textarea asp-for="Html"></textarea>
+    </div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/AdminPageSection/Delete.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Delete.cshtml
@@ -1,0 +1,12 @@
+@model MyWebApp.Models.PageSection
+@{
+    ViewData["Title"] = "Delete Section";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Delete Section</h2>
+<form asp-action="Delete" method="post">
+    <input type="hidden" asp-for="Id" />
+    <p>Are you sure you want to delete <strong>@Model.Area</strong> for page @Model.PageId?</p>
+    <button type="submit">Delete</button>
+    <a asp-action="Index">Cancel</a>
+</form>

--- a/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
@@ -1,0 +1,23 @@
+@model MyWebApp.Models.PageSection
+@{
+    ViewData["Title"] = "Edit Section";
+    Layout = "../Admin/_AdminLayout";
+    var pages = ViewBag.Pages as List<MyWebApp.Models.Page>;
+}
+<h2>Edit Section</h2>
+<form asp-action="Edit" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div>
+        <label>Page</label>
+        <select asp-for="PageId" asp-items="@(new SelectList(pages, "Id", "Slug"))"></select>
+    </div>
+    <div>
+        <label>Area</label>
+        <input asp-for="Area" />
+    </div>
+    <div>
+        <label>Html</label>
+        <textarea asp-for="Html"></textarea>
+    </div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/AdminPageSection/Index.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Index.cshtml
@@ -1,0 +1,23 @@
+@model IEnumerable<MyWebApp.Models.PageSection>
+@{
+    ViewData["Title"] = "Page Sections";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Page Sections</h2>
+<p><a asp-action="Create">Create New</a></p>
+<table>
+    <thead>
+        <tr><th>Page</th><th>Area</th><th colspan="2"></th></tr>
+    </thead>
+    <tbody>
+@foreach (var s in Model)
+{
+    <tr>
+        <td>@s.Page?.Slug</td>
+        <td>@s.Area</td>
+        <td><a asp-action="Edit" asp-route-id="@s.Id">Edit</a></td>
+        <td><a asp-action="Delete" asp-route-id="@s.Id">Delete</a></td>
+    </tr>
+}
+    </tbody>
+</table>


### PR DESCRIPTION
## Summary
- create `PageSection` model and seed layout sections
- adjust context, layout service and pages controller for sections
- add controller and CRUD views to manage page sections
- show new admin nav link
- add unit test for page sections

## Testing
- `~/.dotnet/dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_684d9905a2b8832caedf8c65aaf4d0e7