### PR TITLE
Add setup script for restoring dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ The repository now separates the codebase into two main parts:
 
 ## Restoring Dependencies
 
-After cloning the repository, restore the required packages for the website:
+After cloning the repository, execute the setup script to restore all
+dependencies:
 
 ```bash
-cd website
-dotnet restore MyWebApp.sln
-libman restore
+./setup.sh
+# On Windows you can run ./setup.ps1 instead
 ```
-`libman restore` downloads client-side libraries, including the Quill editor
-used on the admin content pages.
+The script runs `dotnet restore website/MyWebApp.sln` followed by
+`libman restore` in `website/MyWebApp` to download the client-side
+libraries, including the Quill editor used on the admin content pages.
 
 ## Configuring the Database Connection
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,11 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+
+# Restore .NET packages for the solution
+
+dotnet restore website/MyWebApp.sln
+
+# Restore client-side libraries using libman
+Push-Location website/MyWebApp
+libman restore
+Pop-Location

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore .NET packages for the solution
+
+dotnet restore website/MyWebApp.sln
+
+# Restore client-side libraries using libman
+(
+  cd website/MyWebApp
+  libman restore
+)

--- a/website/MyWebApp/MyWebApp.csproj
+++ b/website/MyWebApp/MyWebApp.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add cross-platform setup scripts
- update README with instructions to run the new script
- ensure library restore runs during build by referencing LibraryManager.Build

## Testing
- `dotnet test website/MyWebApp.sln` *(fails: bootstrap, jquery, quill, tinymce could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684e7478cf70832c94ad496da223e8c7