### PR TITLE
Add Html Sanitizer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ dependencies:
 The script runs `dotnet restore website/MyWebApp.sln` followed by
 `libman restore` in `website/MyWebApp` to download the client-side
 libraries, including the Quill editor used on the admin content pages.
+All submitted HTML is sanitized on the server using the `HtmlSanitizer`
+library before being stored.
 
 ## Configuring the Database Connection
 

--- a/website/MyWebApp.Tests/SanitizationTests.cs
+++ b/website/MyWebApp.Tests/SanitizationTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.AspNetCore.Mvc;
+using MyWebApp.Controllers;
+using MyWebApp.Data;
+using MyWebApp.Models;
+using MyWebApp.Services;
+using Xunit;
+
+public class SanitizationTests
+{
+    private static (ApplicationDbContext ctx, LayoutService layout, HtmlSanitizerService sanitizer) CreateServices()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        var ctx = new ApplicationDbContext(options);
+        ctx.Database.EnsureCreated();
+        var memory = new MemoryCache(new MemoryCacheOptions());
+        var cache = new CacheService(memory);
+        var layout = new LayoutService(cache);
+        var sanitizer = new HtmlSanitizerService();
+        return (ctx, layout, sanitizer);
+    }
+
+    [Fact]
+    public async Task CreatePage_SanitizesHtml()
+    {
+        var (ctx, layout, sanitizer) = CreateServices();
+        var controller = new AdminContentController(ctx, layout, sanitizer);
+        var model = new Page
+        {
+            Slug = "test",
+            Title = "Test",
+            HeaderHtml = "<script>alert(1)</script><p>h</p>",
+            BodyHtml = "<p>b</p><script>alert(2)</script>",
+            FooterHtml = "<script>alert(3)</script>f"
+        };
+        var result = await controller.Create(model);
+        Assert.IsType<RedirectToActionResult>(result);
+        var page = ctx.Pages.Single(p => p.Slug == "test");
+        Assert.DoesNotContain("<script", page.HeaderHtml, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<script", page.BodyHtml, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<script", page.FooterHtml, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateSection_SanitizesHtml()
+    {
+        var (ctx, layout, sanitizer) = CreateServices();
+        var controller = new AdminPageSectionController(ctx, layout, sanitizer);
+        var model = new PageSection { PageId = ctx.Pages.First().Id, Area = "test", Html = "<div>hi</div><script>bad()</script>" };
+        var result = await controller.Create(model);
+        Assert.IsType<RedirectToActionResult>(result);
+        var section = ctx.PageSections.First();
+        Assert.DoesNotContain("<script", section.Html, System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/website/MyWebApp/Controllers/AdminContentController.cs
+++ b/website/MyWebApp/Controllers/AdminContentController.cs
@@ -13,11 +13,13 @@ public class AdminContentController : Controller
 {
     private readonly ApplicationDbContext _db;
     private readonly LayoutService _layout;
+    private readonly HtmlSanitizerService _sanitizer;
 
-    public AdminContentController(ApplicationDbContext db, LayoutService layout)
+    public AdminContentController(ApplicationDbContext db, LayoutService layout, HtmlSanitizerService sanitizer)
     {
         _db = db;
         _layout = layout;
+        _sanitizer = sanitizer;
     }
 
     public async Task<IActionResult> Index()
@@ -39,6 +41,9 @@ public class AdminContentController : Controller
         {
             return View(model);
         }
+        model.HeaderHtml = _sanitizer.Sanitize(model.HeaderHtml);
+        model.BodyHtml = _sanitizer.Sanitize(model.BodyHtml);
+        model.FooterHtml = _sanitizer.Sanitize(model.FooterHtml);
         if (model.IsPublished && model.PublishDate == null)
         {
             model.PublishDate = DateTime.UtcNow;
@@ -67,6 +72,9 @@ public class AdminContentController : Controller
         {
             return View(model);
         }
+        model.HeaderHtml = _sanitizer.Sanitize(model.HeaderHtml);
+        model.BodyHtml = _sanitizer.Sanitize(model.BodyHtml);
+        model.FooterHtml = _sanitizer.Sanitize(model.FooterHtml);
         if (model.IsPublished && model.PublishDate == null)
         {
             model.PublishDate = DateTime.UtcNow;

--- a/website/MyWebApp/Controllers/AdminPageSectionController.cs
+++ b/website/MyWebApp/Controllers/AdminPageSectionController.cs
@@ -13,11 +13,13 @@ public class AdminPageSectionController : Controller
 {
     private readonly ApplicationDbContext _db;
     private readonly LayoutService _layout;
+    private readonly HtmlSanitizerService _sanitizer;
 
-    public AdminPageSectionController(ApplicationDbContext db, LayoutService layout)
+    public AdminPageSectionController(ApplicationDbContext db, LayoutService layout, HtmlSanitizerService sanitizer)
     {
         _db = db;
         _layout = layout;
+        _sanitizer = sanitizer;
     }
 
     public async Task<IActionResult> Index()
@@ -49,6 +51,7 @@ public class AdminPageSectionController : Controller
             await LoadPagesAsync();
             return View(model);
         }
+        model.Html = _sanitizer.Sanitize(model.Html);
         _db.PageSections.Add(model);
         await _db.SaveChangesAsync();
         _layout.Reset();
@@ -72,6 +75,7 @@ public class AdminPageSectionController : Controller
             await LoadPagesAsync();
             return View(model);
         }
+        model.Html = _sanitizer.Sanitize(model.Html);
         _db.Update(model);
         await _db.SaveChangesAsync();
         _layout.Reset();

--- a/website/MyWebApp/MyWebApp.csproj
+++ b/website/MyWebApp/MyWebApp.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -139,6 +139,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddSession();
 builder.Services.AddSingleton<MyWebApp.Services.CacheService>();
 builder.Services.AddSingleton<MyWebApp.Services.LayoutService>();
+builder.Services.AddSingleton<MyWebApp.Services.HtmlSanitizerService>();
 builder.Services.AddScoped<MyWebApp.Services.SchemaValidator>();
 builder.Services.AddOptions<MyWebApp.Options.AdminAuthOptions>()
     .Bind(builder.Configuration.GetSection("AdminAuth"))

--- a/website/MyWebApp/Services/HtmlSanitizerService.cs
+++ b/website/MyWebApp/Services/HtmlSanitizerService.cs
@@ -1,0 +1,13 @@
+using Ganss.Xss;
+
+namespace MyWebApp.Services;
+
+public class HtmlSanitizerService
+{
+    private readonly HtmlSanitizer _sanitizer = new();
+
+    public string Sanitize(string? html)
+    {
+        return html == null ? string.Empty : _sanitizer.Sanitize(html);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize HTML on save using HtmlSanitizer
- inject sanitization in admin controllers
- test sanitization removes script tags
- document server-side HTML sanitization in README

## Testing
- `dotnet build website/MyWebApp.sln -p:LibraryRestore=false`
- `dotnet test website/MyWebApp.sln -p:LibraryRestore=false`


------
https://chatgpt.com/codex/tasks/task_e_684ee19dd3f0832c9fc2b1b0e44bd5e1