### PR TITLE
Fix Quill script path in admin layout

### DIFF
--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="~/css/admin.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/lib/quill/dist/quill.snow.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="~/lib/quill/dist/quill.min.js"></script>
+    <script src="~/lib/quill/dist/quill.js" asp-append-version="true"></script>
 </head>
 <body>
     <header class="site-header admin-header">


### PR DESCRIPTION
## Summary
- load correct Quill editor script in the admin layout

## Testing
- `dotnet test MyWebApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb8ca2fdc832c80f7ba217607ecc5