### PR TITLE
Fix duplicate login and add theme support

### DIFF
--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -141,6 +141,7 @@ builder.Services.AddSession();
 builder.Services.AddSingleton<MyWebApp.Services.CacheService>();
 builder.Services.AddSingleton<MyWebApp.Services.LayoutService>();
 builder.Services.AddSingleton<MyWebApp.Services.HtmlSanitizerService>();
+builder.Services.AddSingleton<MyWebApp.Services.ThemeService>();
 builder.Services.AddScoped<MyWebApp.Services.SchemaValidator>();
 builder.Services.AddOptions<MyWebApp.Options.AdminAuthOptions>()
     .Bind(builder.Configuration.GetSection("AdminAuth"))

--- a/website/MyWebApp/Services/ThemeService.cs
+++ b/website/MyWebApp/Services/ThemeService.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Configuration;
+
+namespace MyWebApp.Services;
+
+public class ThemeService
+{
+    private readonly IConfiguration _config;
+
+    public ThemeService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public string ThemeName => _config["Theme:Name"] ?? "dark";
+
+    public string GetCssPath()
+    {
+        return $"~/css/theme-{ThemeName}.css";
+    }
+}

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -1,6 +1,8 @@
 @{
     Layout = null;
 }
+@using MyWebApp.Services
+@inject ThemeService ThemeService
 <!DOCTYPE html>
 <html>
 <head>
@@ -9,6 +11,7 @@
     <title>Admin - Screen Area Recorder Pro</title>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/admin.css" asp-append-version="true" />
+    <link rel="stylesheet" href="@(ThemeService.GetCssPath())" asp-append-version="true" />
     <link rel="stylesheet" href="~/lib/quill/dist/quill.snow.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="~/lib/quill/dist/quill.js" asp-append-version="true"></script>

--- a/website/MyWebApp/Views/Shared/_Layout.cshtml
+++ b/website/MyWebApp/Views/Shared/_Layout.cshtml
@@ -5,10 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Screen Area Recorder Pro</title>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="@(ThemeService.GetCssPath())" asp-append-version="true" />
 </head>
 @using MyWebApp.Services
 @using MyWebApp.Data
 @inject LayoutService LayoutService
+@inject ThemeService ThemeService
 @inject ApplicationDbContext Db
 @{
     var headerHtml = ViewBag.HeaderHtml as string ?? await LayoutService.GetHeaderAsync(Db);
@@ -17,9 +19,6 @@
 <body>
     <header class="site-header">
         @Html.Raw(headerHtml)
-        <nav class="site-nav login-nav">
-            <a href="/Account/Login">Login</a>
-        </nav>
     </header>
     <div class="container">
         <main role="main" class="pb-3">

--- a/website/MyWebApp/appsettings.Development.json
+++ b/website/MyWebApp/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Theme": {
+    "Name": "dark"
   }
 }

--- a/website/MyWebApp/appsettings.json
+++ b/website/MyWebApp/appsettings.json
@@ -18,5 +18,8 @@
   "AdminAuth": {
     "Username": "",
     "Password": ""
+  },
+  "Theme": {
+    "Name": "dark"
   }
 }

--- a/website/MyWebApp/wwwroot/css/theme-dark.css
+++ b/website/MyWebApp/wwwroot/css/theme-dark.css
@@ -1,0 +1,23 @@
+:root {
+    --bg-dark: #121212;
+    --bg-secondary: #1e1e1e;
+    --text-light: #e0e0e0;
+    --text-muted: #bbb;
+    --accent: #0078d4;
+    --accent-hover: #005aa0;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--text-light);
+}
+
+.admin-header {
+    background: var(--bg-secondary);
+    color: var(--text-light);
+}
+
+.admin-main .card {
+    background: var(--bg-secondary);
+    color: var(--text-light);
+}


### PR DESCRIPTION
## Summary
- remove extra login link from layout
- add a ThemeService and a dark theme stylesheet
- load the selected theme in both layouts
- register ThemeService and add configuration section

## Testing
- `dotnet test MyWebApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fca39f4b8832c8e08cf8b7ce3945e