### PR TITLE
Fix missing Media table schema on older databases

### DIFF
--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -175,6 +175,7 @@ using (var scope = app.Services.CreateScope())
                 UpgradeDownloadFilesTable(db);
                 UpgradePageSectionsTable(db);
                 UpgradePagesTable(db);
+                UpgradeMediaTable(db);
             }
         if (db.Database.CanConnect())
         {
@@ -362,6 +363,36 @@ static void UpgradePagesTable(ApplicationDbContext db)
         if (!columns.Contains("FeaturedImage"))
         {
             db.Database.ExecuteSqlRaw("ALTER TABLE Pages ADD COLUMN FeaturedImage TEXT");
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Schema upgrade failed: {ex.Message}");
+    }
+}
+
+static void UpgradeMediaTable(ApplicationDbContext db)
+{
+    try
+    {
+        using var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='Media'";
+        var exists = cmd.ExecuteScalar() != null;
+        if (!exists)
+        {
+            db.Database.ExecuteSqlRaw(@"CREATE TABLE Media (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                FileName TEXT NOT NULL,
+                FilePath TEXT NOT NULL,
+                ContentType TEXT,
+                Size INTEGER NOT NULL,
+                AltText TEXT,
+                Uploaded TEXT NOT NULL
+            )");
+            db.Database.ExecuteSqlRaw("CREATE INDEX IX_Media_FileName ON Media(FileName)");
         }
     }
     catch (Exception ex)


### PR DESCRIPTION
## Summary
- upgrade SQLite schema when the Media table does not exist
- call the new upgrade helper during application startup

## Testing
- `dotnet test MyWebApp.sln` *(fails: libman could not download libraries)*

------
https://chatgpt.com/codex/tasks/task_e_684fe3a19520832ca10a56f447fc92f5