### PR TITLE
Fix missing Scripts section in admin layout

### DIFF
--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -37,5 +37,6 @@
     <main class="admin-main container">
         @RenderBody()
     </main>
+    @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render optional Scripts section in the admin layout

## Testing
- `dotnet build website/MyWebApp.sln -clp:Summary --nologo` *(fails: libman could not download libraries)*
- `dotnet test website/MyWebApp.sln -clp:Summary --nologo` *(fails: libman could not download libraries)*

------
https://chatgpt.com/codex/tasks/task_e_684fe3a19520832ca10a56f447fc92f5