### PR TITLE
Update setup security and download list

### DIFF
--- a/website/MyWebApp.Tests/HomeControllerTests.cs
+++ b/website/MyWebApp.Tests/HomeControllerTests.cs
@@ -76,8 +76,8 @@ public class HomeControllerTests
         };
         var result = controller.Index();
         var redirect = Assert.IsType<RedirectToActionResult>(result);
-        Assert.Equal("Index", redirect.ActionName);
-        Assert.Equal("Setup", redirect.ControllerName);
+        Assert.Equal("Login", redirect.ActionName);
+        Assert.Equal("Account", redirect.ControllerName);
     }
 
     private class FakeTempProvider : ITempDataProvider

--- a/website/MyWebApp/Controllers/BaseController.cs
+++ b/website/MyWebApp/Controllers/BaseController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MyWebApp.Data;
+using Microsoft.AspNetCore.Http;
 
 namespace MyWebApp.Controllers;
 
@@ -29,6 +30,11 @@ public abstract class BaseController : Controller
         }
     }
 
+    protected bool IsAdmin()
+    {
+        return HttpContext.Session.GetString("IsAdmin") == "true";
+    }
+
     protected IActionResult RedirectToSetup(Exception? ex = null)
     {
         if (ex != null)
@@ -40,6 +46,13 @@ public abstract class BaseController : Controller
         {
             TempData["DbError"] = "Database connection failed";
         }
-        return RedirectToAction("Index", "Setup");
+
+        if (IsAdmin())
+        {
+            return RedirectToAction("Index", "Setup");
+        }
+
+        var returnUrl = Url.Action("Index", "Setup");
+        return RedirectToAction("Login", "Account", new { returnUrl });
     }
 }

--- a/website/MyWebApp/Controllers/SetupController.cs
+++ b/website/MyWebApp/Controllers/SetupController.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using MyWebApp.Services;
 using System.Data.Common;
+using Microsoft.AspNetCore.Http;
 
 namespace MyWebApp.Controllers;
 
@@ -26,6 +27,18 @@ public class SetupController : BaseController
 
     public IActionResult Index()
     {
+        if (CheckDatabase())
+        {
+            // database is available, no need for setup
+            return RedirectToAction("Index", "Home");
+        }
+
+        if (HttpContext.Session.GetString("IsAdmin") != "true")
+        {
+            var returnUrl = Url.Action(nameof(Index));
+            return RedirectToAction("Login", "Account", new { returnUrl });
+        }
+
         var error = TempData != null ? TempData["DbError"]?.ToString() : null;
         var result = TempData != null ? TempData["SetupResult"]?.ToString() : null;
         var connection = _config.GetConnectionString("DefaultConnection") ?? string.Empty;
@@ -52,6 +65,12 @@ public class SetupController : BaseController
     [HttpPost]
     public IActionResult UseSqlite()
     {
+        if (HttpContext.Session.GetString("IsAdmin") != "true")
+        {
+            var returnUrl = Url.Action(nameof(Index));
+            return RedirectToAction("Login", "Account", new { returnUrl });
+        }
+
         if (_config is IConfigurationRoot root)
         {
             foreach (var provider in root.Providers)
@@ -68,6 +87,12 @@ public class SetupController : BaseController
     [HttpPost]
     public IActionResult Test(string provider, string server, string database, string username, string password)
     {
+        if (HttpContext.Session.GetString("IsAdmin") != "true")
+        {
+            var returnUrl = Url.Action(nameof(Index));
+            return RedirectToAction("Login", "Account", new { returnUrl });
+        }
+
         var connectionString = ConnectionHelper.BuildConnectionString(provider, server, database, username, password);
         var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
         switch (provider.ToLowerInvariant())
@@ -108,6 +133,12 @@ public class SetupController : BaseController
     [HttpPost]
     public IActionResult Save(string provider, string server, string database, string username, string password)
     {
+        if (HttpContext.Session.GetString("IsAdmin") != "true")
+        {
+            var returnUrl = Url.Action(nameof(Index));
+            return RedirectToAction("Login", "Account", new { returnUrl });
+        }
+
         try
         {
             var connectionString = ConnectionHelper.BuildConnectionString(provider, server, database, username, password);
@@ -170,6 +201,12 @@ public class SetupController : BaseController
     [HttpPost]
     public IActionResult Seed()
     {
+        if (HttpContext.Session.GetString("IsAdmin") != "true")
+        {
+            var returnUrl = Url.Action(nameof(Index));
+            return RedirectToAction("Login", "Account", new { returnUrl });
+        }
+
         if (!CheckDatabase())
         {
             return RedirectToSetup();
@@ -201,5 +238,13 @@ public class SetupController : BaseController
         return RedirectToAction(nameof(Index));
     }
 
-    public IActionResult Import() => View();
+    public IActionResult Import()
+    {
+        if (HttpContext.Session.GetString("IsAdmin") != "true")
+        {
+            var returnUrl = Url.Action(nameof(Index));
+            return RedirectToAction("Login", "Account", new { returnUrl });
+        }
+        return View();
+    }
 }

--- a/website/MyWebApp/Views/Download/Index.cshtml
+++ b/website/MyWebApp/Views/Download/Index.cshtml
@@ -9,12 +9,17 @@
 
 <form method="post" asp-controller="Download" asp-action="Index" id="download-form">
     <input type="hidden" name="token" id="captcha-token" />
-    <select name="fileId">
+    <ul class="download-list">
         @foreach (var f in Model)
         {
-            <option value="@f.Id">@f.FileName - @Html.Raw(f.Description)</option>
+            <li>
+                <label>
+                    <input type="radio" name="fileId" value="@f.Id" />
+                    <strong>@f.FileName</strong> - @Html.Raw(f.Description)
+                </label>
+            </li>
         }
-    </select>
+    </ul>
     <button class="download-btn" type="submit" id="download-btn" disabled>Download</button>
 </form>
 

--- a/website/MyWebApp/wwwroot/css/site.css
+++ b/website/MyWebApp/wwwroot/css/site.css
@@ -89,6 +89,16 @@ body {
     margin-top: 1rem;
 }
 
+.download-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0;
+}
+
+.download-list li {
+    margin-bottom: 0.5rem;
+}
+
 .features {
     max-width: 900px;
     margin: 2rem auto;


### PR DESCRIPTION
## Summary
- restrict setup page access to logged-in admins only
- show login page when database errors occur
- switch download page to a list layout
- tweak CSS for download list
- update unit tests for new setup workflow

## Testing
- `dotnet test MyWebApp.sln` *(fails: LIB002 library restore errors)*

------
https://chatgpt.com/codex/tasks/task_e_684febfc7260832cbf92fd05ccb28497