### PR TITLE
Add CAPTCHA and password recovery

### DIFF
--- a/website/MyWebApp/Controllers/AccountController.cs
+++ b/website/MyWebApp/Controllers/AccountController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using MyWebApp.Data;
 using MyWebApp.Models;
+using MyWebApp.Services;
 using System.Data.Common;
 
 namespace MyWebApp.Controllers;
@@ -9,10 +10,14 @@ namespace MyWebApp.Controllers;
 public class AccountController : Controller
 {
     private readonly ApplicationDbContext _db;
+    private readonly RecaptchaService _recaptcha;
+    private readonly IEmailSender _emailSender;
 
-    public AccountController(ApplicationDbContext db)
+    public AccountController(ApplicationDbContext db, RecaptchaService recaptcha, IEmailSender emailSender)
     {
         _db = db;
+        _recaptcha = recaptcha;
+        _emailSender = emailSender;
     }
 
     [HttpGet]
@@ -27,6 +32,13 @@ public class AccountController : Controller
         if (!ModelState.IsValid)
         {
             model.ErrorMessage = "Invalid data";
+            return View(model);
+        }
+
+        var captchaResponse = Request.Form["g-recaptcha-response"].ToString();
+        if (!await _recaptcha.VerifyAsync(captchaResponse))
+        {
+            model.ErrorMessage = "CAPTCHA validation failed.";
             return View(model);
         }
 
@@ -66,5 +78,90 @@ public class AccountController : Controller
         HttpContext.Session.Remove("IsAdmin");
         HttpContext.Session.Remove("AdminUser");
         return RedirectToAction("Index", "Home");
+    }
+
+    [HttpGet]
+    public IActionResult ForgotPassword()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ForgotPassword(string username)
+    {
+        var captcha = Request.Form["g-recaptcha-response"].ToString();
+        if (!await _recaptcha.VerifyAsync(captcha))
+        {
+            ModelState.AddModelError(string.Empty, "CAPTCHA validation failed.");
+            return View();
+        }
+
+        var expired = _db.PasswordResetTokens.Where(t => t.Expiration < DateTime.UtcNow || t.Used);
+        if (expired.Any())
+        {
+            _db.PasswordResetTokens.RemoveRange(expired);
+            await _db.SaveChangesAsync();
+        }
+
+        var cred = await _db.AdminCredentials.FirstOrDefaultAsync();
+        if (cred != null && string.Equals(username, cred.Username, StringComparison.OrdinalIgnoreCase))
+        {
+            var token = new PasswordResetToken
+            {
+                AdminCredentialId = cred.Id,
+                Token = Guid.NewGuid().ToString("N"),
+                Expiration = DateTime.UtcNow.AddHours(1),
+                Used = false
+            };
+            _db.PasswordResetTokens.Add(token);
+            await _db.SaveChangesAsync();
+
+            var link = Url.Action(nameof(ResetPassword), "Account", new { token = token.Token }, Request.Scheme);
+            await _emailSender.SendEmailAsync(cred.Username, "Password Reset", $"Reset your password: {link}");
+        }
+
+        ViewBag.Message = "If the account exists, a recovery link was sent.";
+        return View();
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> ResetPassword(string token)
+    {
+        var reset = await _db.PasswordResetTokens
+            .Include(p => p.AdminCredential)
+            .FirstOrDefaultAsync(t => t.Token == token && !t.Used && t.Expiration > DateTime.UtcNow);
+        if (reset == null)
+            return RedirectToAction(nameof(Login));
+        ViewBag.Token = token;
+        return View();
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ResetPassword(string token, string password)
+    {
+        var captcha = Request.Form["g-recaptcha-response"].ToString();
+        if (!await _recaptcha.VerifyAsync(captcha))
+        {
+            ModelState.AddModelError(string.Empty, "CAPTCHA validation failed.");
+            ViewBag.Token = token;
+            return View();
+        }
+
+        var reset = await _db.PasswordResetTokens
+            .Include(p => p.AdminCredential)
+            .FirstOrDefaultAsync(t => t.Token == token && !t.Used && t.Expiration > DateTime.UtcNow);
+        if (reset == null)
+            return RedirectToAction(nameof(Login));
+
+        if (reset.AdminCredential != null)
+        {
+            reset.AdminCredential.Password = password;
+            reset.Used = true;
+            await _db.SaveChangesAsync();
+        }
+
+        return RedirectToAction(nameof(Login));
     }
 }

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -18,6 +18,7 @@ namespace MyWebApp.Data
         public DbSet<PageSection> PageSections { get; set; }
         public DbSet<AdminCredential> AdminCredentials { get; set; }
         public DbSet<Media> MediaItems { get; set; }
+        public DbSet<PasswordResetToken> PasswordResetTokens { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -45,6 +46,10 @@ namespace MyWebApp.Data
 
             modelBuilder.Entity<PageSection>()
                 .HasIndex(s => new { s.PageId, s.Area })
+                .IsUnique();
+
+            modelBuilder.Entity<PasswordResetToken>()
+                .HasIndex(t => t.Token)
                 .IsUnique();
 
             modelBuilder.Entity<Page>().HasData(

--- a/website/MyWebApp/Models/LoginViewModel.cs
+++ b/website/MyWebApp/Models/LoginViewModel.cs
@@ -6,5 +6,6 @@ namespace MyWebApp.Models
         public string Password { get; set; } = string.Empty;
         public string? ReturnUrl { get; set; }
         public string? ErrorMessage { get; set; }
+        public string? RecaptchaToken { get; set; }
     }
 }

--- a/website/MyWebApp/Models/PasswordResetToken.cs
+++ b/website/MyWebApp/Models/PasswordResetToken.cs
@@ -1,0 +1,12 @@
+namespace MyWebApp.Models
+{
+    public class PasswordResetToken
+    {
+        public int Id { get; set; }
+        public int AdminCredentialId { get; set; }
+        public string Token { get; set; } = string.Empty;
+        public DateTime Expiration { get; set; }
+        public bool Used { get; set; }
+        public AdminCredential? AdminCredential { get; set; }
+    }
+}

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -137,13 +137,21 @@ builder.Services.AddDbContextFactory<MyWebApp.Data.ApplicationDbContext>((sp, op
 builder.Services.AddControllersWithViews();
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();
-builder.Services.AddSession();
+var sessionTimeout = builder.Configuration.GetValue<int>("Session:TimeoutMinutes", 30);
+builder.Services.AddSession(options =>
+{
+    options.IdleTimeout = TimeSpan.FromMinutes(sessionTimeout);
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+});
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<MyWebApp.Services.CacheService>();
 builder.Services.AddSingleton<MyWebApp.Services.LayoutService>();
 builder.Services.AddSingleton<MyWebApp.Services.HtmlSanitizerService>();
 builder.Services.AddSingleton<MyWebApp.Services.ThemeService>();
 builder.Services.AddSingleton<MyWebApp.Services.CaptchaService>();
+builder.Services.AddSingleton<MyWebApp.Services.RecaptchaService>();
+builder.Services.AddSingleton<MyWebApp.Services.IEmailSender, MyWebApp.Services.LoggingEmailSender>();
 builder.Services.AddScoped<MyWebApp.Services.SchemaValidator>();
 builder.Services.AddOptions<MyWebApp.Options.AdminAuthOptions>()
     .Bind(builder.Configuration.GetSection("AdminAuth"))

--- a/website/MyWebApp/Services/EmailSender.cs
+++ b/website/MyWebApp/Services/EmailSender.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace MyWebApp.Services
+{
+    public interface IEmailSender
+    {
+        Task SendEmailAsync(string email, string subject, string message);
+    }
+
+    public class LoggingEmailSender : IEmailSender
+    {
+        private readonly ILogger<LoggingEmailSender> _logger;
+        public LoggingEmailSender(ILogger<LoggingEmailSender> logger)
+        {
+            _logger = logger;
+        }
+        public Task SendEmailAsync(string email, string subject, string message)
+        {
+            _logger.LogInformation("Sending email to {Email} - {Subject}\n{Message}", email, subject, message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/website/MyWebApp/Services/RecaptchaService.cs
+++ b/website/MyWebApp/Services/RecaptchaService.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+namespace MyWebApp.Services
+{
+    public class RecaptchaService
+    {
+        private readonly IHttpClientFactory _factory;
+        private readonly IConfiguration _config;
+
+        public RecaptchaService(IHttpClientFactory factory, IConfiguration config)
+        {
+            _factory = factory;
+            _config = config;
+        }
+
+        public async Task<bool> VerifyAsync(string? token)
+        {
+            if (string.IsNullOrEmpty(token))
+                return false;
+
+            var secret = _config["Captcha:SecretKey"];
+            var verifyUrl = _config["Captcha:VerifyUrl"] ?? "https://www.google.com/recaptcha/api/siteverify";
+            var parameters = new Dictionary<string, string?>
+            {
+                ["secret"] = secret,
+                ["response"] = token
+            };
+            var client = _factory.CreateClient();
+            try
+            {
+                using var response = await client.PostAsync(verifyUrl, new FormUrlEncodedContent(parameters));
+                if (!response.IsSuccessStatusCode)
+                    return false;
+                var stream = await response.Content.ReadAsStreamAsync();
+                var result = await JsonSerializer.DeserializeAsync<RecaptchaResponse>(stream);
+                return result?.Success == true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private class RecaptchaResponse
+        {
+            public bool Success { get; set; }
+        }
+    }
+}

--- a/website/MyWebApp/Views/Account/ForgotPassword.cshtml
+++ b/website/MyWebApp/Views/Account/ForgotPassword.cshtml
@@ -1,0 +1,20 @@
+@{
+    ViewData["Title"] = "Forgot Password";
+}
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
+<h2>Forgot Password</h2>
+@if(ViewBag.Message != null)
+{
+    <div class="text-success">@ViewBag.Message</div>
+}
+<form method="post" asp-action="ForgotPassword" asp-controller="Account">
+    <div class="form-group">
+        <label for="username">Username</label>
+        <input type="text" name="username" id="username" class="form-control" />
+    </div>
+    <div class="form-group mt-3">
+        <div class="g-recaptcha" data-sitekey="@Configuration["Captcha:SiteKey"]"></div>
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">Send Link</button>
+</form>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/website/MyWebApp/Views/Account/Login.cshtml
+++ b/website/MyWebApp/Views/Account/Login.cshtml
@@ -7,6 +7,7 @@
 {
     <div class="error">@Model.ErrorMessage</div>
 }
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
 <form method="post" asp-action="Login" asp-controller="Account">
     <input type="hidden" asp-for="ReturnUrl" />
     <div class="form-group">
@@ -17,5 +18,13 @@
         <label asp-for="Password"></label>
         <input asp-for="Password" type="password" class="form-control" />
     </div>
-    <button type="submit" class="btn btn-primary">Login</button>
+    <div class="form-group mt-3">
+        <div class="g-recaptcha" data-sitekey="@Configuration["Captcha:SiteKey"]"></div>
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">Login</button>
 </form>
+<div class="mt-2">
+    <a asp-action="ForgotPassword" asp-controller="Account">Forgot Password?</a>
+</div>
+
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/website/MyWebApp/Views/Account/ResetPassword.cshtml
+++ b/website/MyWebApp/Views/Account/ResetPassword.cshtml
@@ -1,0 +1,17 @@
+@{
+    ViewData["Title"] = "Reset Password";
+}
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
+<h2>Reset Password</h2>
+<form method="post" asp-action="ResetPassword" asp-controller="Account">
+    <input type="hidden" name="token" value="@ViewBag.Token" />
+    <div class="form-group">
+        <label for="password">New Password</label>
+        <input type="password" name="password" id="password" class="form-control" />
+    </div>
+    <div class="form-group mt-3">
+        <div class="g-recaptcha" data-sitekey="@Configuration["Captcha:SiteKey"]"></div>
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">Reset</button>
+</form>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/website/MyWebApp/appsettings.json
+++ b/website/MyWebApp/appsettings.json
@@ -11,8 +11,8 @@
   },
   "DatabaseProvider": "SqlServer",
   "Captcha": {
-    "SiteKey": "${CAPTCHA_SITE_KEY}",
-    "SecretKey": "${CAPTCHA_SECRET_KEY}",
+    "SiteKey": "${CAPTCHA_SITE_KEY:-6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI}",
+    "SecretKey": "${CAPTCHA_SECRET_KEY:-6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}",
     "VerifyUrl": "https://www.google.com/recaptcha/api/siteverify"
   },
   "AdminAuth": {
@@ -21,5 +21,8 @@
   },
   "Theme": {
     "Name": "dark"
+  },
+  "Session": {
+    "TimeoutMinutes": 30
   }
 }


### PR DESCRIPTION
## Summary
- implement reCAPTCHA service and integrate into login
- add password reset tokens with views and controller logic
- log emails via new EmailSender
- configure session timeout
- update appsettings defaults

## Testing
- `~/.dotnet/dotnet test website/MyWebApp.Tests/MyWebApp.Tests.csproj -nologo` *(fails: library restore errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ff5fecb64832caf2918db8b59b082