### PR TITLE
Improve registration form UX defaults

### DIFF
--- a/website/MyWebApp/Views/Account/Register.cshtml
+++ b/website/MyWebApp/Views/Account/Register.cshtml
@@ -17,20 +17,20 @@
         <input asp-for="LastName" class="form-control" />
     </div>
     <div class="form-group">
-        <label asp-for="Email"></label>
+        <label asp-for="Email"></label><span class="text-danger">*</span>
         <input asp-for="Email" type="email" class="form-control" />
     </div>
     <div class="form-group">
-        <label asp-for="Username"></label>
+        <label asp-for="Username"></label><span class="text-danger">*</span>
         <input asp-for="Username" class="form-control" />
     </div>
     <div class="form-group">
-        <label asp-for="Password"></label>
+        <label asp-for="Password"></label><span class="text-danger">*</span>
         <input asp-for="Password" type="password" class="form-control" id="pwd" />
         <small id="strength" class="text-muted"></small>
     </div>
     <div class="form-group">
-        <label asp-for="ConfirmPassword"></label>
+        <label asp-for="ConfirmPassword"></label><span class="text-danger">*</span>
         <input asp-for="ConfirmPassword" type="password" class="form-control" />
     </div>
     <div class="form-group">
@@ -41,20 +41,14 @@
         <label asp-for="DateOfBirth"></label>
         <input asp-for="DateOfBirth" type="date" class="form-control" />
     </div>
-    <div class="form-group">
-        <label asp-for="AccountType"></label>
-        <select asp-for="AccountType" class="form-select">
-            <option>User</option>
-            <option>Moderator</option>
-        </select>
-    </div>
+    <input type="hidden" asp-for="AccountType" value="User" />
     <div class="form-check">
         <input asp-for="AcceptTerms" class="form-check-input" type="checkbox" />
-        <label asp-for="AcceptTerms" class="form-check-label">Accept Terms of Service</label>
+        <label asp-for="AcceptTerms" class="form-check-label">Accept Terms of Service</label><span class="text-danger">*</span>
     </div>
     <div class="form-check">
         <input asp-for="AcceptPrivacy" class="form-check-input" type="checkbox" />
-        <label asp-for="AcceptPrivacy" class="form-check-label">Accept Privacy Policy</label>
+        <label asp-for="AcceptPrivacy" class="form-check-label">Accept Privacy Policy</label><span class="text-danger">*</span>
     </div>
     <div class="form-group mt-3">
         <img src="@Url.Action("Image", "Captcha")?t=@ViewBag.CaptchaToken" class="captcha-img" alt="captcha" />


### PR DESCRIPTION
## Summary
- hide account type input so users register with the default `User` role
- indicate required registration fields with a red asterisk

## Testing
- `./setup.sh` *(fails: dotnet not found)*
- `dotnet test MyWebApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850167d3e08832cbfd943d9a032660e