### PR TITLE
Fix setup access check and registration form

### DIFF
--- a/website/MyWebApp/Controllers/AccountController.cs
+++ b/website/MyWebApp/Controllers/AccountController.cs
@@ -19,6 +19,12 @@ public class AccountController : Controller
     private readonly ILogger<AccountController> _logger;
     private static readonly Dictionary<string, (int Count, DateTime LockoutEnd)> _attempts = new();
 
+    private bool HasRole(string role)
+    {
+        var roles = HttpContext.Session.GetString("Roles")?.Split(',') ?? Array.Empty<string>();
+        return roles.Contains(role);
+    }
+
     public AccountController(ApplicationDbContext db, CaptchaService captchaService, IEmailSender emailSender, ILogger<AccountController> logger)
     {
         _db = db;
@@ -279,6 +285,11 @@ public class AccountController : Controller
             _captchaService.CreateChallenge();
             ViewBag.CaptchaToken = DateTime.UtcNow.Ticks;
             return View(model);
+        }
+
+        if (!(HasRole("Admin") || HasRole("Moderator")))
+        {
+            model.AccountType = "User";
         }
 
         var user = new SiteUser

--- a/website/MyWebApp/Filters/RoleAuthorizeAttribute.cs
+++ b/website/MyWebApp/Filters/RoleAuthorizeAttribute.cs
@@ -20,7 +20,8 @@ namespace MyWebApp.Filters
             var roles = session.GetString("Roles")?.Split(',') ?? Array.Empty<string>();
             if (!_roles.Any(r => roles.Contains(r)))
             {
-                context.Result = new ForbidResult();
+                var returnUrl = context.HttpContext.Request.Path + context.HttpContext.Request.QueryString;
+                context.Result = new RedirectToActionResult("Login", "Account", new { returnUrl });
             }
         }
     }

--- a/website/MyWebApp/Views/Account/Register.cshtml
+++ b/website/MyWebApp/Views/Account/Register.cshtml
@@ -1,6 +1,9 @@
 @model MyWebApp.Models.RegisterViewModel
+@using Microsoft.AspNetCore.Http
 @{
     ViewData["Title"] = "Register";
+    var roles = Context.Session.GetString("Roles") ?? string.Empty;
+    bool canSelectType = roles.Contains("Admin") || roles.Contains("Moderator");
 }
 <h2>Register</h2>
 @if (!string.IsNullOrEmpty(Model.ErrorMessage))
@@ -17,20 +20,20 @@
         <input asp-for="LastName" class="form-control" />
     </div>
     <div class="form-group">
-        <label asp-for="Email"></label>
+        <label asp-for="Email"></label><span class="text-danger">*</span>
         <input asp-for="Email" type="email" class="form-control" />
     </div>
     <div class="form-group">
-        <label asp-for="Username"></label>
+        <label asp-for="Username"></label><span class="text-danger">*</span>
         <input asp-for="Username" class="form-control" />
     </div>
     <div class="form-group">
-        <label asp-for="Password"></label>
+        <label asp-for="Password"></label><span class="text-danger">*</span>
         <input asp-for="Password" type="password" class="form-control" id="pwd" />
         <small id="strength" class="text-muted"></small>
     </div>
     <div class="form-group">
-        <label asp-for="ConfirmPassword"></label>
+        <label asp-for="ConfirmPassword"></label><span class="text-danger">*</span>
         <input asp-for="ConfirmPassword" type="password" class="form-control" />
     </div>
     <div class="form-group">
@@ -41,20 +44,27 @@
         <label asp-for="DateOfBirth"></label>
         <input asp-for="DateOfBirth" type="date" class="form-control" />
     </div>
-    <div class="form-group">
-        <label asp-for="AccountType"></label>
-        <select asp-for="AccountType" class="form-select">
-            <option>User</option>
-            <option>Moderator</option>
-        </select>
-    </div>
+    @if (canSelectType)
+    {
+        <div class="form-group">
+            <label asp-for="AccountType"></label>
+            <select asp-for="AccountType" class="form-select">
+                <option>User</option>
+                <option>Moderator</option>
+            </select>
+        </div>
+    }
+    else
+    {
+        <input type="hidden" asp-for="AccountType" value="User" />
+    }
     <div class="form-check">
         <input asp-for="AcceptTerms" class="form-check-input" type="checkbox" />
-        <label asp-for="AcceptTerms" class="form-check-label">Accept Terms of Service</label>
+        <label asp-for="AcceptTerms" class="form-check-label">Accept Terms of Service</label><span class="text-danger">*</span>
     </div>
     <div class="form-check">
         <input asp-for="AcceptPrivacy" class="form-check-input" type="checkbox" />
-        <label asp-for="AcceptPrivacy" class="form-check-label">Accept Privacy Policy</label>
+        <label asp-for="AcceptPrivacy" class="form-check-label">Accept Privacy Policy</label><span class="text-danger">*</span>
     </div>
     <div class="form-group mt-3">
         <img src="@Url.Action("Image", "Captcha")?t=@ViewBag.CaptchaToken" class="captcha-img" alt="captcha" />


### PR DESCRIPTION
## Summary
- redirect unauthorized visitors to login instead of forbidding when using `RoleAuthorize`
- required registration fields show a red `*`
- default registration to `User` role unless current session has admin or moderator role

## Testing
- `./setup.sh` *(fails: dotnet not found)*
- `dotnet test website/MyWebApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850167d3e08832cbfd943d9a032660e