### PR TITLE
Unify admin page editing

### DIFF
--- a/website/MyWebApp/Controllers/AdminContentController.cs
+++ b/website/MyWebApp/Controllers/AdminContentController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
 using MyWebApp.Data;
+using System.Collections.Generic;
 using MyWebApp.Filters;
 using MyWebApp.Models;
 using MyWebApp.Services;
@@ -30,7 +31,8 @@ public class AdminContentController : Controller
 
     public IActionResult Create()
     {
-        return View(new Page());
+        ViewBag.Sections = new List<PageSection>();
+        return View("PageEditor", new Page());
     }
 
     [HttpPost]
@@ -39,7 +41,8 @@ public class AdminContentController : Controller
     {
         if (!ModelState.IsValid)
         {
-            return View(model);
+            ViewBag.Sections = new List<PageSection>();
+            return View("PageEditor", model);
         }
         model.HeaderHtml = _sanitizer.Sanitize(model.HeaderHtml);
         model.BodyHtml = _sanitizer.Sanitize(model.BodyHtml);
@@ -61,7 +64,12 @@ public class AdminContentController : Controller
         {
             return NotFound();
         }
-        return View(page);
+        var sections = await _db.PageSections.AsNoTracking()
+            .Where(s => s.PageId == id)
+            .OrderBy(s => s.Id)
+            .ToListAsync();
+        ViewBag.Sections = sections;
+        return View("PageEditor", page);
     }
 
     [HttpPost]
@@ -70,7 +78,12 @@ public class AdminContentController : Controller
     {
         if (!ModelState.IsValid)
         {
-            return View(model);
+            var sections = await _db.PageSections.AsNoTracking()
+                .Where(s => s.PageId == model.Id)
+                .OrderBy(s => s.Id)
+                .ToListAsync();
+            ViewBag.Sections = sections;
+            return View("PageEditor", model);
         }
         model.HeaderHtml = _sanitizer.Sanitize(model.HeaderHtml);
         model.BodyHtml = _sanitizer.Sanitize(model.BodyHtml);

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -29,7 +29,6 @@
                 <a asp-controller="Files" asp-action="Index">Files</a>
                 <a asp-controller="Media" asp-action="Index">Media</a>
                 <a asp-controller="AdminContent" asp-action="Index">Pages</a>
-                <a asp-controller="AdminPageSection" asp-action="Index">Sections</a>
                 <a asp-controller="Account" asp-action="Logout">Logout</a>
             </nav>
         </div>

--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -1,0 +1,86 @@
+@model MyWebApp.Models.Page
+@using MyWebApp.Models
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
+@{
+    var sections = ViewBag.Sections as List<PageSection> ?? new List<PageSection>();
+    Layout = "../Admin/_AdminLayout";
+    var isNew = Model.Id == 0;
+    ViewData["Title"] = isNew ? "Create Page" : "Edit Page";
+}
+<h2>@ViewData["Title"]</h2>
+<div class="tabs">
+    <button type="button" class="tab-link active" data-target="#tab-settings">Page Settings</button>
+    <button type="button" class="tab-link" data-target="#tab-sections">Content Sections</button>
+</div>
+<form asp-action="@(isNew ? "Create" : "Edit")" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div id="tab-settings" class="tab-content active">
+        <div><label>Slug</label><input asp-for="Slug" /></div>
+        <div><label>Title</label><input asp-for="Title" /></div>
+        <div><label asp-for="MetaDescription"></label><input asp-for="MetaDescription" /></div>
+        <div><label asp-for="MetaKeywords"></label><input asp-for="MetaKeywords" /></div>
+        <div><label asp-for="OgTitle"></label><input asp-for="OgTitle" /></div>
+        <div><label asp-for="OgDescription"></label><input asp-for="OgDescription" /></div>
+        <div><label asp-for="Category"></label><input asp-for="Category" /></div>
+        <div><label asp-for="Tags"></label><input asp-for="Tags" /></div>
+        <div><label asp-for="FeaturedImage"></label><input asp-for="FeaturedImage" /></div>
+        <div><label asp-for="IsPublished"></label><input asp-for="IsPublished" /></div>
+        <div><label asp-for="PublishDate"></label><input asp-for="PublishDate" type="datetime-local" /></div>
+        <div>
+            <label>Header</label>
+            <div id="header-editor" class="quill-editor"></div>
+            <input type="hidden" asp-for="HeaderHtml" />
+        </div>
+        <div>
+            <label>Body</label>
+            <div id="body-editor" class="quill-editor"></div>
+            <input type="hidden" asp-for="BodyHtml" />
+        </div>
+        <div>
+            <label>Footer</label>
+            <div id="footer-editor" class="quill-editor"></div>
+            <input type="hidden" asp-for="FooterHtml" />
+        </div>
+    </div>
+    <div id="tab-sections" class="tab-content" style="display:none">
+        <div id="sections-container">
+@for (int i = 0; i < sections.Count; i++)
+{
+    var vd = new ViewDataDictionary(ViewData) { ["Index"] = i };
+    @await Html.PartialAsync("_SectionEditor", sections[i], vd)
+}
+        </div>
+        <button type="button" id="add-section">Add Section</button>
+        <div id="section-template" style="display:none">
+            @await Html.PartialAsync("_SectionEditor", new PageSection(), new ViewDataDictionary(ViewData) { ["Index"] = "__index__" })
+        </div>
+    </div>
+    <button type="submit">Save</button>
+</form>
+@section Scripts {
+    <script>
+        const headerQuill = new Quill('#header-editor', { theme: 'snow' });
+        const bodyQuill = new Quill('#body-editor', { theme: 'snow' });
+        const footerQuill = new Quill('#footer-editor', { theme: 'snow' });
+        headerQuill.root.innerHTML = document.getElementById('HeaderHtml').value;
+        bodyQuill.root.innerHTML = document.getElementById('BodyHtml').value;
+        footerQuill.root.innerHTML = document.getElementById('FooterHtml').value;
+        document.querySelector('form').addEventListener('submit', function () {
+            document.getElementById('HeaderHtml').value = headerQuill.root.innerHTML;
+            document.getElementById('BodyHtml').value = bodyQuill.root.innerHTML;
+            document.getElementById('FooterHtml').value = footerQuill.root.innerHTML;
+        });
+    </script>
+    <script src="~/js/page-editor.js" asp-append-version="true"></script>
+    <script>
+        document.querySelectorAll('.tab-link').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.tab-link').forEach(b => b.classList.remove('active'));
+                document.querySelectorAll('.tab-content').forEach(c => c.style.display = 'none');
+                btn.classList.add('active');
+                const target = document.querySelector(btn.dataset.target);
+                if (target) target.style.display = 'block';
+            });
+        });
+    </script>
+}

--- a/website/MyWebApp/Views/AdminContent/_SectionEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/_SectionEditor.cshtml
@@ -1,0 +1,17 @@
+@model MyWebApp.Models.PageSection
+@{
+    var index = ViewData["Index"]?.ToString() ?? "0";
+}
+<div class="section-editor" draggable="true">
+    <input type="hidden" name="Sections[@index].Id" value="@Model.Id" />
+    <div>
+        <label>Area</label>
+        <input type="text" name="Sections[@index].Area" value="@Model.Area" />
+    </div>
+    <div>
+        <label>Html</label>
+        <textarea name="Sections[@index].Html">@Model.Html</textarea>
+    </div>
+    <button type="button" class="duplicate-section">Duplicate Section</button>
+    <button type="button" class="remove-section">Remove Section</button>
+</div>

--- a/website/MyWebApp/wwwroot/js/page-editor.js
+++ b/website/MyWebApp/wwwroot/js/page-editor.js
@@ -1,0 +1,57 @@
+window.addEventListener('load', () => {
+    const container = document.getElementById('sections-container');
+    if (!container) return;
+    const templateHtml = document.getElementById('section-template').innerHTML.trim();
+
+    document.getElementById('add-section').addEventListener('click', () => {
+        addSection();
+    });
+
+    container.addEventListener('click', (e) => {
+        if (e.target.classList.contains('remove-section')) {
+            e.target.closest('.section-editor').remove();
+            updateIndexes();
+        } else if (e.target.classList.contains('duplicate-section')) {
+            const original = e.target.closest('.section-editor');
+            const clone = original.cloneNode(true);
+            container.insertBefore(clone, original.nextSibling);
+            updateIndexes();
+        }
+    });
+
+    function addSection() {
+        const index = container.querySelectorAll('.section-editor').length;
+        const html = templateHtml.replace(/__index__/g, index);
+        const temp = document.createElement('div');
+        temp.innerHTML = html;
+        container.appendChild(temp.firstElementChild);
+        updateIndexes();
+    }
+
+    function updateIndexes() {
+        container.querySelectorAll('.section-editor').forEach((el, idx) => {
+            el.querySelectorAll('input, textarea').forEach(input => {
+                input.name = input.name.replace(/Sections\[.*?\]/, `Sections[${idx}]`);
+            });
+        });
+    }
+
+    let dragged = null;
+    container.addEventListener('dragstart', e => {
+        dragged = e.target.closest('.section-editor');
+        e.dataTransfer.effectAllowed = 'move';
+    });
+    container.addEventListener('dragover', e => {
+        e.preventDefault();
+        const target = e.target.closest('.section-editor');
+        if (dragged && target && target !== dragged) {
+            const rect = target.getBoundingClientRect();
+            const next = (e.clientY - rect.top) > (rect.height / 2);
+            container.insertBefore(dragged, next ? target.nextSibling : target);
+        }
+    });
+    container.addEventListener('drop', e => {
+        e.preventDefault();
+        updateIndexes();
+    });
+});


### PR DESCRIPTION
## Summary
- combine create/edit views into `PageEditor`
- remove old *Sections* navigation link
- create `_SectionEditor` partial used for page sections
- add dynamic section editing script
- load sections in the controller for edit/create

## Testing
- `dotnet test MyWebApp.sln` *(fails: HomeControllerTests.Index_RedirectsWhenDbFails, SchemaValidatorTests.Validate_DetectsMissingIndexes)*

------
https://chatgpt.com/codex/tasks/task_e_68503a21c78c832ca3dd273eb96f6b59