### PR TITLE
Add block templates and section scheduling

### DIFF
--- a/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
+++ b/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using MyWebApp.Data;
+using MyWebApp.Filters;
+using MyWebApp.Models;
+using MyWebApp.Services;
+
+namespace MyWebApp.Controllers;
+
+[RoleAuthorize("Admin")]
+public class AdminBlockTemplateController : Controller
+{
+    private readonly ApplicationDbContext _db;
+    private readonly HtmlSanitizerService _sanitizer;
+
+    public AdminBlockTemplateController(ApplicationDbContext db, HtmlSanitizerService sanitizer)
+    {
+        _db = db;
+        _sanitizer = sanitizer;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var items = await _db.BlockTemplates.AsNoTracking().OrderBy(t => t.Name).ToListAsync();
+        return View(items);
+    }
+
+    public IActionResult Create()
+    {
+        return View(new BlockTemplate());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(BlockTemplate model)
+    {
+        if (!ModelState.IsValid) return View(model);
+        model.Html = _sanitizer.Sanitize(model.Html);
+        _db.BlockTemplates.Add(model);
+        _db.BlockTemplateVersions.Add(new BlockTemplateVersion { BlockTemplate = model, Html = model.Html });
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var item = await _db.BlockTemplates.FindAsync(id);
+        if (item == null) return NotFound();
+        return View(item);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(BlockTemplate model)
+    {
+        if (!ModelState.IsValid) return View(model);
+        model.Html = _sanitizer.Sanitize(model.Html);
+        _db.Update(model);
+        _db.BlockTemplateVersions.Add(new BlockTemplateVersion { BlockTemplateId = model.Id, Html = model.Html });
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Delete(int id)
+    {
+        var item = await _db.BlockTemplates.FindAsync(id);
+        if (item == null) return NotFound();
+        return View(item);
+    }
+
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var item = await _db.BlockTemplates.FindAsync(id);
+        if (item != null)
+        {
+            _db.BlockTemplates.Remove(item);
+            await _db.SaveChangesAsync();
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Export()
+    {
+        var list = await _db.BlockTemplates.AsNoTracking().ToListAsync();
+        var json = JsonSerializer.Serialize(list);
+        return File(System.Text.Encoding.UTF8.GetBytes(json), "application/json", "blocks.json");
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Import(IFormFile? file)
+    {
+        if (file == null || file.Length == 0) return RedirectToAction(nameof(Index));
+        using var reader = new StreamReader(file.OpenReadStream());
+        var json = await reader.ReadToEndAsync();
+        var list = JsonSerializer.Deserialize<List<BlockTemplate>>(json) ?? new();
+        foreach (var t in list)
+        {
+            t.Id = 0;
+            t.Html = _sanitizer.Sanitize(t.Html);
+            _db.BlockTemplates.Add(t);
+            _db.BlockTemplateVersions.Add(new BlockTemplateVersion { BlockTemplate = t, Html = t.Html });
+        }
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/website/MyWebApp/Controllers/AdminContentController.cs
+++ b/website/MyWebApp/Controllers/AdminContentController.cs
@@ -22,14 +22,21 @@ public class AdminContentController : Controller
         _sanitizer = sanitizer;
     }
 
+    private async Task LoadTemplatesAsync()
+    {
+        ViewBag.Templates = await _db.BlockTemplates.AsNoTracking()
+            .OrderBy(t => t.Name).ToListAsync();
+    }
+
     public async Task<IActionResult> Index()
     {
         var pages = await _db.Pages.AsNoTracking().OrderBy(p => p.Slug).ToListAsync();
         return View(pages);
     }
 
-    public IActionResult Create()
+    public async Task<IActionResult> Create()
     {
+        await LoadTemplatesAsync();
         return View(new Page());
     }
 
@@ -39,6 +46,7 @@ public class AdminContentController : Controller
     {
         if (!ModelState.IsValid)
         {
+            await LoadTemplatesAsync();
             return View(model);
         }
         model.HeaderHtml = _sanitizer.Sanitize(model.HeaderHtml);
@@ -61,6 +69,7 @@ public class AdminContentController : Controller
         {
             return NotFound();
         }
+        await LoadTemplatesAsync();
         return View(page);
     }
 
@@ -70,6 +79,7 @@ public class AdminContentController : Controller
     {
         if (!ModelState.IsValid)
         {
+            await LoadTemplatesAsync();
             return View(model);
         }
         model.HeaderHtml = _sanitizer.Sanitize(model.HeaderHtml);

--- a/website/MyWebApp/Controllers/AdminPageSectionController.cs
+++ b/website/MyWebApp/Controllers/AdminPageSectionController.cs
@@ -22,18 +22,23 @@ public class AdminPageSectionController : Controller
         _sanitizer = sanitizer;
     }
 
-    public async Task<IActionResult> Index()
+    public async Task<IActionResult> Index(string? q)
     {
-        var sections = await _db.PageSections.AsNoTracking()
-            .Include(s => s.Page)
-            .OrderBy(s => s.Page.Slug).ThenBy(s => s.Area)
-            .ToListAsync();
+        var query = _db.PageSections.AsNoTracking().Include(s => s.Page).AsQueryable();
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            q = q.ToLowerInvariant();
+            query = query.Where(s => s.Area.ToLower().Contains(q) || s.Html.ToLower().Contains(q) || s.Page.Slug.ToLower().Contains(q));
+        }
+        var sections = await query.OrderBy(s => s.Page.Slug).ThenBy(s => s.Area).ToListAsync();
+        ViewBag.Query = q;
         return View(sections);
     }
 
     private async Task LoadPagesAsync()
     {
         ViewBag.Pages = await _db.Pages.AsNoTracking().OrderBy(p => p.Slug).ToListAsync();
+        ViewBag.Permissions = await _db.Permissions.AsNoTracking().OrderBy(p => p.Name).ToListAsync();
     }
 
     public async Task<IActionResult> Create()

--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -25,6 +25,8 @@ namespace MyWebApp.Data
         public DbSet<UserRole> UserRoles { get; set; }
         public DbSet<RolePermission> RolePermissions { get; set; }
         public DbSet<EmailVerificationToken> EmailVerificationTokens { get; set; }
+        public DbSet<BlockTemplate> BlockTemplates { get; set; }
+        public DbSet<BlockTemplateVersion> BlockTemplateVersions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -53,6 +55,13 @@ namespace MyWebApp.Data
             modelBuilder.Entity<PageSection>()
                 .HasIndex(s => new { s.PageId, s.Area })
                 .IsUnique();
+            modelBuilder.Entity<PageSection>()
+                .Property(s => s.ViewCount)
+                .HasDefaultValue(0);
+            modelBuilder.Entity<PageSection>()
+                .HasOne(s => s.Permission)
+                .WithMany()
+                .HasForeignKey(s => s.PermissionId);
 
             modelBuilder.Entity<PasswordResetToken>()
                 .HasIndex(t => t.Token)
@@ -75,6 +84,10 @@ namespace MyWebApp.Data
 
             modelBuilder.Entity<EmailVerificationToken>()
                 .HasIndex(t => t.Token)
+                .IsUnique();
+
+            modelBuilder.Entity<BlockTemplate>()
+                .HasIndex(t => t.Name)
                 .IsUnique();
 
             modelBuilder.Entity<Page>().HasData(
@@ -101,13 +114,15 @@ namespace MyWebApp.Data
                     PageId = 1,
                     Area = "header",
                     Html = "<div class=\"container-fluid nav-container\"><a class=\"logo\" href=\"/\">Screen Area Recorder Pro</a><nav class=\"site-nav\"><a href=\"/\">Home</a> <a href=\"/Download\">Download</a> <a href=\"/Home/Faq\">FAQ</a> <a href=\"/Home/Privacy\">Privacy</a> <a href=\"/Setup\">Setup</a> <a href=\"/Account/Login\">Login</a></nav></div>"
+                    , ViewCount = 0
                 },
                 new PageSection
                 {
                     Id = 2,
                     PageId = 1,
                     Area = "footer",
-                    Html = "<div class=\"container\">&copy; 2025 - Screen Area Recorder Pro</div>"
+                    Html = "<div class=\"container\">&copy; 2025 - Screen Area Recorder Pro</div>",
+                    ViewCount = 0
                 });
 
             modelBuilder.Entity<Role>().HasData(

--- a/website/MyWebApp/Models/BlockTemplate.cs
+++ b/website/MyWebApp/Models/BlockTemplate.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace MyWebApp.Models;
+
+public class BlockTemplate
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(128)]
+    public string Name { get; set; } = string.Empty;
+
+    public string Html { get; set; } = string.Empty;
+
+    public ICollection<BlockTemplateVersion> Versions { get; set; } = new List<BlockTemplateVersion>();
+}

--- a/website/MyWebApp/Models/BlockTemplateVersion.cs
+++ b/website/MyWebApp/Models/BlockTemplateVersion.cs
@@ -1,0 +1,18 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace MyWebApp.Models;
+
+public class BlockTemplateVersion
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int BlockTemplateId { get; set; }
+
+    public string Html { get; set; } = string.Empty;
+
+    public DateTime Created { get; set; } = DateTime.UtcNow;
+
+    public BlockTemplate? Template { get; set; }
+}

--- a/website/MyWebApp/Models/PageSection.cs
+++ b/website/MyWebApp/Models/PageSection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace MyWebApp.Models;
@@ -15,5 +16,15 @@ public class PageSection
 
     public string Html { get; set; } = string.Empty;
 
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public int? PermissionId { get; set; }
+
+    public int ViewCount { get; set; }
+
     public Page? Page { get; set; }
+
+    public Permission? Permission { get; set; }
 }

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -192,6 +192,7 @@ using (var scope = app.Services.CreateScope())
                 UpgradePageSectionsTable(db);
                 UpgradePagesTable(db);
                 UpgradeMediaItemsTable(db);
+                UpgradeBlockTemplatesTable(db);
             }
         if (db.Database.CanConnect())
         {
@@ -315,12 +316,35 @@ static void UpgradePageSectionsTable(ApplicationDbContext db)
                 PageId INTEGER NOT NULL,
                 Area TEXT NOT NULL,
                 Html TEXT,
+                StartDate TEXT,
+                EndDate TEXT,
+                PermissionId INTEGER,
+                ViewCount INTEGER NOT NULL DEFAULT 0,
                 FOREIGN KEY(PageId) REFERENCES Pages(Id) ON DELETE CASCADE
             )");
             db.Database.ExecuteSqlRaw("CREATE UNIQUE INDEX IX_PageSections_PageId_Area ON PageSections(PageId, Area)");
             db.Database.ExecuteSqlRaw(@"INSERT INTO PageSections (Id, PageId, Area, Html) VALUES
                 (1, 1, 'header', '<div class ""container-fluid nav-container""><a class=""logo"" href=""/"">Screen Area Recorder Pro</a><nav class=""site-nav""><a href=""/"">Home</a> <a href=""/Download"">Download</a> <a href=""/Home/Faq"">FAQ</a> <a href=""/Home/Privacy"">Privacy</a> <a href=""/Setup"">Setup</a> <a href=""/Account/Login"">Login</a></nav></div>'),
                 (2, 1, 'footer', '<div class ""container"">&copy; 2025 - Screen Area Recorder Pro</div>')");
+        }
+        else
+        {
+            cmd.CommandText = "PRAGMA table_info('PageSections')";
+            using var reader = cmd.ExecuteReader();
+            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            while (reader.Read())
+            {
+                columns.Add(reader.GetString(1));
+            }
+            reader.Close();
+            if (!columns.Contains("StartDate"))
+                db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN StartDate TEXT");
+            if (!columns.Contains("EndDate"))
+                db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN EndDate TEXT");
+            if (!columns.Contains("PermissionId"))
+                db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN PermissionId INTEGER");
+            if (!columns.Contains("ViewCount"))
+                db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN ViewCount INTEGER NOT NULL DEFAULT 0");
         }
     }
     catch (Exception ex)
@@ -409,6 +433,44 @@ static void UpgradeMediaItemsTable(ApplicationDbContext db)
                 Uploaded TEXT NOT NULL
             )");
             db.Database.ExecuteSqlRaw("CREATE INDEX IX_MediaItems_FileName ON MediaItems(FileName)");
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Schema upgrade failed: {ex.Message}");
+    }
+}
+
+static void UpgradeBlockTemplatesTable(ApplicationDbContext db)
+{
+    try
+    {
+        using var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='BlockTemplates'";
+        var exists = cmd.ExecuteScalar() != null;
+        if (!exists)
+        {
+            db.Database.ExecuteSqlRaw(@"CREATE TABLE BlockTemplates (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL,
+                Html TEXT
+            )");
+            db.Database.ExecuteSqlRaw("CREATE UNIQUE INDEX IX_BlockTemplates_Name ON BlockTemplates(Name)");
+        }
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='BlockTemplateVersions'";
+        exists = cmd.ExecuteScalar() != null;
+        if (!exists)
+        {
+            db.Database.ExecuteSqlRaw(@"CREATE TABLE BlockTemplateVersions (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                BlockTemplateId INTEGER NOT NULL,
+                Html TEXT,
+                Created TEXT NOT NULL,
+                FOREIGN KEY(BlockTemplateId) REFERENCES BlockTemplates(Id) ON DELETE CASCADE
+            )");
         }
     }
     catch (Exception ex)

--- a/website/MyWebApp/Services/LayoutService.cs
+++ b/website/MyWebApp/Services/LayoutService.cs
@@ -40,10 +40,14 @@ public class LayoutService
 
     public async Task<string> GetSectionAsync(ApplicationDbContext db, int pageId, string area)
     {
-        return await db.PageSections.AsNoTracking()
-            .Where(s => s.PageId == pageId && s.Area == area)
-            .Select(s => s.Html)
-            .FirstOrDefaultAsync() ?? string.Empty;
+        var section = await db.PageSections
+            .FirstOrDefaultAsync(s => s.PageId == pageId && s.Area == area
+                && (s.StartDate == null || s.StartDate <= DateTime.UtcNow)
+                && (s.EndDate == null || s.EndDate >= DateTime.UtcNow));
+        if (section == null) return string.Empty;
+        section.ViewCount++;
+        await db.SaveChangesAsync();
+        return section.Html;
     }
 
     public void Reset()

--- a/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
+++ b/website/MyWebApp/Views/Admin/_AdminLayout.cshtml
@@ -28,6 +28,7 @@
                 <a asp-controller="Admin" asp-action="Logs">Logs</a>
                 <a asp-controller="Files" asp-action="Index">Files</a>
                 <a asp-controller="Media" asp-action="Index">Media</a>
+                <a asp-controller="AdminBlockTemplate" asp-action="Index">Blocks</a>
                 <a asp-controller="AdminContent" asp-action="Index">Pages</a>
                 <a asp-controller="AdminPageSection" asp-action="Index">Sections</a>
                 <a asp-controller="Account" asp-action="Logout">Logout</a>

--- a/website/MyWebApp/Views/AdminBlockTemplate/Create.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Create.cshtml
@@ -1,0 +1,11 @@
+@model MyWebApp.Models.BlockTemplate
+@{
+    ViewData["Title"] = "Create Block";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Create Block</h2>
+<form asp-action="Create" method="post">
+    <div><label>Name</label><input asp-for="Name" /></div>
+    <div><label>Html</label><textarea asp-for="Html"></textarea></div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/AdminBlockTemplate/Delete.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Delete.cshtml
@@ -1,0 +1,11 @@
+@model MyWebApp.Models.BlockTemplate
+@{
+    ViewData["Title"] = "Delete Block";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Delete Block</h2>
+<form asp-action="Delete" method="post">
+    <input type="hidden" asp-for="Id" />
+    <p>Are you sure you want to delete <strong>@Model.Name</strong>?</p>
+    <button type="submit">Delete</button>
+</form>

--- a/website/MyWebApp/Views/AdminBlockTemplate/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Edit.cshtml
@@ -1,0 +1,12 @@
+@model MyWebApp.Models.BlockTemplate
+@{
+    ViewData["Title"] = "Edit Block";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Edit Block</h2>
+<form asp-action="Edit" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div><label>Name</label><input asp-for="Name" /></div>
+    <div><label>Html</label><textarea asp-for="Html"></textarea></div>
+    <button type="submit">Save</button>
+</form>

--- a/website/MyWebApp/Views/AdminBlockTemplate/Index.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Index.cshtml
@@ -1,0 +1,24 @@
+@model IEnumerable<MyWebApp.Models.BlockTemplate>
+@{
+    ViewData["Title"] = "Block Templates";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>Block Templates</h2>
+<p><a asp-action="Create">Create New</a> | <a asp-action="Export">Export</a></p>
+<form asp-action="Import" method="post" enctype="multipart/form-data">
+    <input type="file" name="file" />
+    <button type="submit">Import</button>
+</form>
+<table>
+    <thead><tr><th>Name</th><th></th><th></th></tr></thead>
+    <tbody>
+@foreach (var t in Model)
+{
+    <tr>
+        <td>@t.Name</td>
+        <td><a asp-action="Edit" asp-route-id="@t.Id">Edit</a></td>
+        <td><a asp-action="Delete" asp-route-id="@t.Id">Delete</a></td>
+    </tr>
+}
+    </tbody>
+</table>

--- a/website/MyWebApp/Views/AdminContent/Create.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Create.cshtml
@@ -2,6 +2,7 @@
 @{
     ViewData["Title"] = "Create Page";
     Layout = "../Admin/_AdminLayout";
+    var templates = ViewBag.Templates as List<MyWebApp.Models.BlockTemplate>;
 }
 <h2>Create Page</h2>
 <form asp-action="Create" method="post">
@@ -27,6 +28,17 @@
         <input type="hidden" asp-for="BodyHtml" />
     </div>
     <div>
+        <label>Insert Block</label>
+        <select id="template-select">
+            <option value="">--select--</option>
+            @foreach (var t in templates)
+            {
+                <option value="@t.Id">@t.Name</option>
+            }
+        </select>
+        <button type="button" id="insert-template">Insert</button>
+    </div>
+    <div>
         <label>Footer</label>
         <div id="footer-editor" class="quill-editor"></div>
         <input type="hidden" asp-for="FooterHtml" />
@@ -45,4 +57,16 @@
         document.getElementById('BodyHtml').value = bodyQuill.root.innerHTML;
         document.getElementById('FooterHtml').value = footerQuill.root.innerHTML;
     });
+    const templates = JSON.parse(document.getElementById('templates-data').textContent);
+    document.getElementById('insert-template').addEventListener('click', function () {
+        const sel = document.getElementById('template-select');
+        const id = parseInt(sel.value);
+        const tpl = templates.find(t => t.id === id);
+        if (tpl) {
+            bodyQuill.clipboard.dangerouslyPasteHTML(bodyQuill.getLength(), tpl.html);
+        }
+    });
+</script>
+<script id="templates-data" type="application/json">
+@Html.Raw(System.Text.Json.JsonSerializer.Serialize(templates))
 </script>

--- a/website/MyWebApp/Views/AdminContent/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminContent/Edit.cshtml
@@ -2,6 +2,7 @@
 @{
     ViewData["Title"] = "Edit Page";
     Layout = "../Admin/_AdminLayout";
+    var templates = ViewBag.Templates as List<MyWebApp.Models.BlockTemplate>;
 }
 <h2>Edit Page</h2>
 <form asp-action="Edit" method="post">
@@ -28,6 +29,17 @@
         <input type="hidden" asp-for="BodyHtml" />
     </div>
     <div>
+        <label>Insert Block</label>
+        <select id="template-select">
+            <option value="">--select--</option>
+            @foreach (var t in templates)
+            {
+                <option value="@t.Id">@t.Name</option>
+            }
+        </select>
+        <button type="button" id="insert-template">Insert</button>
+    </div>
+    <div>
         <label>Footer</label>
         <div id="footer-editor" class="quill-editor"></div>
         <input type="hidden" asp-for="FooterHtml" />
@@ -46,4 +58,16 @@
         document.getElementById('BodyHtml').value = bodyQuill.root.innerHTML;
         document.getElementById('FooterHtml').value = footerQuill.root.innerHTML;
     });
+    const templates = JSON.parse(document.getElementById('templates-data').textContent);
+    document.getElementById('insert-template').addEventListener('click', function () {
+        const sel = document.getElementById('template-select');
+        const id = parseInt(sel.value);
+        const tpl = templates.find(t => t.id === id);
+        if (tpl) {
+            bodyQuill.clipboard.dangerouslyPasteHTML(bodyQuill.getLength(), tpl.html);
+        }
+    });
+</script>
+<script id="templates-data" type="application/json">
+@Html.Raw(System.Text.Json.JsonSerializer.Serialize(templates))
 </script>

--- a/website/MyWebApp/Views/AdminPageSection/Create.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Create.cshtml
@@ -1,8 +1,9 @@
 @model MyWebApp.Models.PageSection
-@{
+@{ 
     ViewData["Title"] = "Create Section";
     Layout = "../Admin/_AdminLayout";
     var pages = ViewBag.Pages as List<MyWebApp.Models.Page>;
+    var permissions = ViewBag.Permissions as List<MyWebApp.Models.Permission>;
 }
 <h2>Create Section</h2>
 <form asp-action="Create" method="post">
@@ -17,6 +18,20 @@
     <div>
         <label>Html</label>
         <textarea asp-for="Html"></textarea>
+    </div>
+    <div>
+        <label>Start Date</label>
+        <input asp-for="StartDate" type="datetime-local" />
+    </div>
+    <div>
+        <label>End Date</label>
+        <input asp-for="EndDate" type="datetime-local" />
+    </div>
+    <div>
+        <label>Permission</label>
+        <select asp-for="PermissionId" asp-items="@(new SelectList(permissions, "Id", "Name"))">
+            <option value="">(none)</option>
+        </select>
     </div>
     <button type="submit">Save</button>
 </form>

--- a/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
@@ -3,6 +3,7 @@
     ViewData["Title"] = "Edit Section";
     Layout = "../Admin/_AdminLayout";
     var pages = ViewBag.Pages as List<MyWebApp.Models.Page>;
+    var permissions = ViewBag.Permissions as List<MyWebApp.Models.Permission>;
 }
 <h2>Edit Section</h2>
 <form asp-action="Edit" method="post">
@@ -18,6 +19,20 @@
     <div>
         <label>Html</label>
         <textarea asp-for="Html"></textarea>
+    </div>
+    <div>
+        <label>Start Date</label>
+        <input asp-for="StartDate" type="datetime-local" />
+    </div>
+    <div>
+        <label>End Date</label>
+        <input asp-for="EndDate" type="datetime-local" />
+    </div>
+    <div>
+        <label>Permission</label>
+        <select asp-for="PermissionId" asp-items="@(new SelectList(permissions, "Id", "Name"))">
+            <option value="">(none)</option>
+        </select>
     </div>
     <button type="submit">Save</button>
 </form>

--- a/website/MyWebApp/Views/AdminPageSection/Index.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Index.cshtml
@@ -4,10 +4,14 @@
     Layout = "../Admin/_AdminLayout";
 }
 <h2>Page Sections</h2>
+<form method="get" asp-action="Index">
+    <input type="text" name="q" value="@ViewBag.Query" placeholder="Search" />
+    <button type="submit">Search</button>
+</form>
 <p><a asp-action="Create">Create New</a></p>
 <table>
     <thead>
-        <tr><th>Page</th><th>Area</th><th colspan="2"></th></tr>
+        <tr><th>Page</th><th>Area</th><th>Views</th><th colspan="2"></th></tr>
     </thead>
     <tbody>
 @foreach (var s in Model)
@@ -15,6 +19,7 @@
     <tr>
         <td>@s.Page?.Slug</td>
         <td>@s.Area</td>
+        <td>@s.ViewCount</td>
         <td><a asp-action="Edit" asp-route-id="@s.Id">Edit</a></td>
         <td><a asp-action="Delete" asp-route-id="@s.Id">Delete</a></td>
     </tr>


### PR DESCRIPTION
## Summary
- create `BlockTemplate` and version models
- add admin interface for managing block templates
- allow inserting block templates in page editor
- schedule sections with start/end dates and permissions
- store view counts per section and add search/filter UI

## Testing
- `dotnet test MyWebApp.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503a33d2fc832ca792d220397ca8e6