### PR TITLE
Add SortOrder property to PageSection model

### DIFF
--- a/website/MyWebApp/Data/ApplicationDbContext.cs
+++ b/website/MyWebApp/Data/ApplicationDbContext.cs
@@ -109,6 +109,7 @@ namespace MyWebApp.Data
                     Id = 1,
                     PageId = 1,
                     Area = "header",
+                    SortOrder = 0,
  
                     Type = PageSectionType.Html,
  
@@ -120,6 +121,7 @@ namespace MyWebApp.Data
                     Id = 2,
                     PageId = 1,
                     Area = "footer",
+                    SortOrder = 0,
  
                     Type = PageSectionType.Html,
  

--- a/website/MyWebApp/Models/PageSection.cs
+++ b/website/MyWebApp/Models/PageSection.cs
@@ -23,6 +23,8 @@ public class PageSection
     [MaxLength(64)]
     public string Area { get; set; } = string.Empty;
 
+    public int SortOrder { get; set; }
+
  
     public PageSectionType Type { get; set; } = PageSectionType.Html;
  


### PR DESCRIPTION
## Summary
- add missing `SortOrder` property on `PageSection`
- seed default `SortOrder` values in `ApplicationDbContext`

## Testing
- `dotnet test MyWebApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685038344564832c9da27e5767aaaa41