### PR TITLE
Fix website build

### DIFF
--- a/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
+++ b/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
@@ -41,7 +41,7 @@ public class AdminBlockTemplateController : Controller
         if (!ModelState.IsValid) return View(model);
         model.Html = _sanitizer.Sanitize(model.Html);
         _db.BlockTemplates.Add(model);
-        _db.BlockTemplateVersions.Add(new BlockTemplateVersion { BlockTemplate = model, Html = model.Html });
+        _db.BlockTemplateVersions.Add(new BlockTemplateVersion { Template = model, Html = model.Html });
         await _db.SaveChangesAsync();
         return RedirectToAction(nameof(Index));
     }
@@ -105,7 +105,7 @@ public class AdminBlockTemplateController : Controller
             t.Id = 0;
             t.Html = _sanitizer.Sanitize(t.Html);
             _db.BlockTemplates.Add(t);
-            _db.BlockTemplateVersions.Add(new BlockTemplateVersion { BlockTemplate = t, Html = t.Html });
+            _db.BlockTemplateVersions.Add(new BlockTemplateVersion { Template = t, Html = t.Html });
         }
         await _db.SaveChangesAsync();
         return RedirectToAction(nameof(Index));

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -337,21 +337,9 @@ static void UpgradePageSectionsTable(ApplicationDbContext db)
             {
                 columns.Add(reader.GetString(1));
             }
-            if (!columns.Contains("Type"))
-            {
-                db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN Type INTEGER NOT NULL DEFAULT 0");
-            }
-        }
-        else
-        {
-            cmd.CommandText = "PRAGMA table_info('PageSections')";
-            using var reader = cmd.ExecuteReader();
-            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            while (reader.Read())
-            {
-                columns.Add(reader.GetString(1));
-            }
             reader.Close();
+            if (!columns.Contains("Type"))
+                db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN Type INTEGER NOT NULL DEFAULT 0");
             if (!columns.Contains("StartDate"))
                 db.Database.ExecuteSqlRaw("ALTER TABLE PageSections ADD COLUMN StartDate TEXT");
             if (!columns.Contains("EndDate"))


### PR DESCRIPTION
## Summary
- resolve mismatched navigation property in the block template admin controller
- remove duplicate `else` block in schema upgrade routine

## Testing
- `dotnet build MyWebApp.sln`
- `dotnet test MyWebApp.sln` *(fails: SchemaValidatorTests.Validate_DetectsMissingIndexes, HomeControllerTests.Index_RedirectsWhenDbFails)*

------
https://chatgpt.com/codex/tasks/task_e_68504b1a7a80832c8e46eaf0a180791c