### PR TITLE
Add block template insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ dotnet test MyWebApp.sln
 
 This will build the solution and run all tests.
 
+## Block Templates
+
+Reusable page blocks can be managed under the **Blocks** section of the admin
+panel. Each block stores a fragment of HTML that can be inserted while editing a
+page. When working in the page editor click inside a section so the Quill editor
+is focused, then choose a block from the "Insert template" dropdown. The HTML is
+loaded from `/AdminBlockTemplate/Html/{id}` and placed directly into the active
+editor.
+
 ## Chrome Extension
 
 The extension source resides in the `extension/` folder. Load this folder in

--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -40,6 +40,18 @@
     @await Html.PartialAsync("_SectionEditor", sections[i], vd)
 }
     </div>
+    @if (ViewBag.Templates is List<BlockTemplate> templates && templates.Count > 0)
+    {
+        <div class="my-2">
+            <select id="template-selector">
+                <option value="">Insert template...</option>
+                @foreach (var t in templates)
+                {
+                    <option value="@t.Id">@t.Name</option>
+                }
+            </select>
+        </div>
+    }
     <button type="button" id="add-section">Add Section</button>
     <div id="section-template" style="display:none">
         @await Html.PartialAsync("_SectionEditor", new PageSection(), new ViewDataDictionary(ViewData) { ["Index"] = "__index__" })

--- a/website/MyWebApp/wwwroot/js/page-editor.js
+++ b/website/MyWebApp/wwwroot/js/page-editor.js
@@ -4,6 +4,29 @@ window.addEventListener('load', () => {
     const templateHtml = document.getElementById('section-template').innerHTML.trim();
     let sectionCount = container.querySelectorAll('.section-editor').length;
     const editors = {};
+    let activeIndex = null;
+
+    const templateSelect = document.getElementById('template-selector');
+    if (templateSelect) {
+        templateSelect.addEventListener('change', () => {
+            const id = templateSelect.value;
+            if (!id) return;
+            if (activeIndex === null || !editors[activeIndex]) {
+                alert('Select a section first');
+                templateSelect.value = '';
+                return;
+            }
+            fetch(`/AdminBlockTemplate/Html/${id}`)
+                .then(r => r.text())
+                .then(html => {
+                    const quill = editors[activeIndex];
+                    quill.root.innerHTML = html;
+                    const input = document.getElementById(`Html-${activeIndex}`);
+                    if (input) input.value = html;
+                    templateSelect.value = '';
+                });
+        });
+    }
 
     container.querySelectorAll('.section-editor').forEach(el => {
         const idx = el.dataset.index;
@@ -119,6 +142,8 @@ window.addEventListener('load', () => {
         const code = codeDiv ? codeDiv.querySelector('textarea') : null;
         const quill = new Quill(`#quill-editor-${index}`, { theme: 'snow' });
         quill.root.innerHTML = quillInput.value || '';
+        quill.root.addEventListener('click', () => { activeIndex = index; });
+        quill.root.addEventListener('focus', () => { activeIndex = index; });
         editors[index] = quill;
 
         function update() {


### PR DESCRIPTION
## Summary
- allow admins to insert block templates while editing pages
- support inserting the chosen template into the selected Quill editor
- document how to use block templates in the editor

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_685105eee310832c9ca4becc194139e2