### PR TITLE
Add block page support

### DIFF
--- a/website/MyWebApp/TagHelpers/PageBlocksTagHelper.cs
+++ b/website/MyWebApp/TagHelpers/PageBlocksTagHelper.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+
+namespace MyWebApp.TagHelpers;
+
+[HtmlTargetElement("page-blocks")]
+public class PageBlocksTagHelper : TagHelper
+{
+    private readonly ApplicationDbContext _db;
+    public PageBlocksTagHelper(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public int PageId { get; set; }
+    public string Area { get; set; } = string.Empty;
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = null;
+        var htmlParts = await _db.PageSections.AsNoTracking()
+            .Where(s => s.PageId == PageId && s.Area == Area)
+            .OrderBy(s => s.SortOrder)
+            .Select(s => s.Html)
+            .ToListAsync();
+        output.Content.SetHtmlContent(string.Join(System.Environment.NewLine, htmlParts));
+    }
+}

--- a/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
@@ -1,0 +1,23 @@
+@using MyWebApp.Models
+@{
+    ViewData["Title"] = "Add Block To Page";
+    Layout = "../Admin/_AdminLayout";
+}
+<h2>@ViewData["Title"]</h2>
+<form asp-action="AddToPage" method="post">
+    <input type="hidden" name="id" value="@ViewBag.BlockId" />
+    <div>
+        <label>Page</label>
+        <select name="pageId">
+            @foreach (var p in ViewBag.Pages as List<Page>)
+            {
+                <option value="@p.Id">@p.Slug</option>
+            }
+        </select>
+    </div>
+    <div>
+        <label>Area</label>
+        <input type="text" name="area" />
+    </div>
+    <button type="submit">Add</button>
+</form>

--- a/website/MyWebApp/Views/AdminBlockTemplate/Index.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Index.cshtml
@@ -10,7 +10,7 @@
     <button type="submit">Import</button>
 </form>
 <table>
-    <thead><tr><th>Name</th><th></th><th></th></tr></thead>
+    <thead><tr><th>Name</th><th></th><th></th><th></th></tr></thead>
     <tbody>
 @foreach (var t in Model)
 {
@@ -18,6 +18,7 @@
         <td>@t.Name</td>
         <td><a asp-action="Edit" asp-route-id="@t.Id">Edit</a></td>
         <td><a asp-action="Delete" asp-route-id="@t.Id">Delete</a></td>
+        <td><a asp-action="AddToPage" asp-route-id="@t.Id">Add to Page</a></td>
     </tr>
 }
     </tbody>

--- a/website/MyWebApp/Views/_ViewImports.cshtml
+++ b/website/MyWebApp/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using MyWebApp
 @using MyWebApp.Models
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, MyWebApp


### PR DESCRIPTION
## Summary
- load pages in block admin controller
- add ability to store blocks on a page
- expose `<page-blocks>` tag helper for rendering blocks
- list Add to Page option

## Testing
- `~/.dotnet/dotnet build -clp:ErrorsOnly`
- `~/.dotnet/dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_68510d322c50832c9e35a6875d3cb461