### PR TITLE
Enable block insertion into templates

### DIFF
--- a/website/MyWebApp.Tests/SanitizationTests.cs
+++ b/website/MyWebApp.Tests/SanitizationTests.cs
@@ -22,7 +22,8 @@ public class SanitizationTests
         ctx.Database.EnsureCreated();
         var memory = new MemoryCache(new MemoryCacheOptions());
         var cache = new CacheService(memory);
-        var layout = new LayoutService(cache);
+        var tokens = new TokenRenderService();
+        var layout = new LayoutService(cache, tokens);
         var sanitizer = new HtmlSanitizerService();
         return (ctx, layout, sanitizer);
     }

--- a/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
+++ b/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
@@ -168,4 +168,36 @@ public class AdminBlockTemplateController : Controller
         await _db.SaveChangesAsync();
         return RedirectToAction(nameof(Index));
     }
+
+    [HttpGet]
+    public async Task<IActionResult> GetBlocks()
+    {
+        var items = await _db.BlockTemplates.AsNoTracking()
+            .OrderBy(t => t.Name)
+            .Select(t => new { t.Id, t.Name })
+            .ToListAsync();
+        return Json(items);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetPages()
+    {
+        var pages = await _db.Pages.AsNoTracking()
+            .OrderBy(p => p.Slug)
+            .Select(p => new { p.Id, p.Slug })
+            .ToListAsync();
+        return Json(pages);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetSections(int id)
+    {
+        var areas = await _db.PageSections.AsNoTracking()
+            .Where(s => s.PageId == id)
+            .Select(s => s.Area)
+            .Distinct()
+            .OrderBy(a => a)
+            .ToListAsync();
+        return Json(areas);
+    }
 }

--- a/website/MyWebApp/Program.cs
+++ b/website/MyWebApp/Program.cs
@@ -147,6 +147,7 @@ builder.Services.AddSession(options =>
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<MyWebApp.Services.CacheService>();
 builder.Services.AddSingleton<MyWebApp.Services.LayoutService>();
+builder.Services.AddSingleton<MyWebApp.Services.TokenRenderService>();
 builder.Services.AddSingleton<MyWebApp.Services.HtmlSanitizerService>();
 builder.Services.AddSingleton<MyWebApp.Services.ThemeService>();
 builder.Services.AddSingleton<MyWebApp.Services.CaptchaService>();

--- a/website/MyWebApp/Services/LayoutService.cs
+++ b/website/MyWebApp/Services/LayoutService.cs
@@ -6,6 +6,7 @@ namespace MyWebApp.Services;
 public class LayoutService
 {
     private readonly CacheService _cache;
+    private readonly TokenRenderService _tokens;
     private const string HeaderKey = "layout_header";
     private const string FooterKey = "layout_footer";
 
@@ -15,9 +16,10 @@ public class LayoutService
         ["two-column-sidebar"] = new[] { "main", "sidebar" }
     };
 
-    public LayoutService(CacheService cache)
+    public LayoutService(CacheService cache, TokenRenderService tokens)
     {
         _cache = cache;
+        _tokens = tokens;
     }
 
     public async Task<string> GetHeaderAsync(ApplicationDbContext db)
@@ -30,7 +32,8 @@ public class LayoutService
                 .OrderBy(s => s.SortOrder)
                 .Select(s => s.Html)
                 .ToListAsync();
-            return string.Join(System.Environment.NewLine, parts);
+            var html = string.Join(System.Environment.NewLine, parts);
+            return await _tokens.RenderAsync(db, html);
         });
     }
 
@@ -44,7 +47,8 @@ public class LayoutService
                 .OrderBy(s => s.SortOrder)
                 .Select(s => s.Html)
                 .ToListAsync();
-            return string.Join(System.Environment.NewLine, parts);
+            var html = string.Join(System.Environment.NewLine, parts);
+            return await _tokens.RenderAsync(db, html);
         });
     }
 
@@ -56,7 +60,8 @@ public class LayoutService
             .OrderBy(s => s.SortOrder)
             .Select(s => s.Html)
             .ToListAsync();
-        return string.Join(System.Environment.NewLine, parts);
+        var html = string.Join(System.Environment.NewLine, parts);
+        return await _tokens.RenderAsync(db, html);
  
     }
 

--- a/website/MyWebApp/Services/TokenRenderService.cs
+++ b/website/MyWebApp/Services/TokenRenderService.cs
@@ -1,0 +1,62 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using MyWebApp.Data;
+
+namespace MyWebApp.Services;
+
+public class TokenRenderService
+{
+    private static readonly Regex TokenRegex = new(@"\{\{(block|section):([^{}]+)\}\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public Task<string> RenderAsync(ApplicationDbContext db, string html)
+    {
+        return RenderAsync(db, html, new HashSet<int>());
+    }
+
+    private async Task<string> RenderAsync(ApplicationDbContext db, string html, HashSet<int> stack)
+    {
+        async Task<string> Replace(Match match)
+        {
+            var type = match.Groups[1].Value.ToLowerInvariant();
+            var param = match.Groups[2].Value;
+            if (type == "block")
+            {
+                if (!int.TryParse(param, out var id)) return string.Empty;
+                if (stack.Contains(id)) return string.Empty;
+                stack.Add(id);
+                var block = await db.BlockTemplates.AsNoTracking().FirstOrDefaultAsync(b => b.Id == id);
+                var result = block == null ? string.Empty : await RenderAsync(db, block.Html, stack);
+                stack.Remove(id);
+                return result;
+            }
+            else if (type == "section")
+            {
+                var parts = param.Split(':', 2);
+                if (parts.Length == 2 && int.TryParse(parts[0], out var pageId))
+                {
+                    var area = parts[1];
+                    var htmlParts = await db.PageSections.AsNoTracking()
+                        .Where(s => s.PageId == pageId && s.Area == area)
+                        .OrderBy(s => s.SortOrder)
+                        .Select(s => s.Html)
+                        .ToListAsync();
+                    var combined = string.Join(System.Environment.NewLine, htmlParts);
+                    return await RenderAsync(db, combined, stack);
+                }
+                return string.Empty;
+            }
+            return string.Empty;
+        }
+
+        var result = new System.Text.StringBuilder();
+        int last = 0;
+        foreach (Match m in TokenRegex.Matches(html))
+        {
+            result.Append(html, last, m.Index - last);
+            result.Append(await Replace(m));
+            last = m.Index + m.Length;
+        }
+        result.Append(html, last, html.Length - last);
+        return result.ToString();
+    }
+}

--- a/website/MyWebApp/TagHelpers/PageBlocksTagHelper.cs
+++ b/website/MyWebApp/TagHelpers/PageBlocksTagHelper.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.EntityFrameworkCore;
 using MyWebApp.Data;
+using MyWebApp.Services;
 
 namespace MyWebApp.TagHelpers;
 
@@ -8,9 +9,11 @@ namespace MyWebApp.TagHelpers;
 public class PageBlocksTagHelper : TagHelper
 {
     private readonly ApplicationDbContext _db;
-    public PageBlocksTagHelper(ApplicationDbContext db)
+    private readonly TokenRenderService _tokens;
+    public PageBlocksTagHelper(ApplicationDbContext db, TokenRenderService tokens)
     {
         _db = db;
+        _tokens = tokens;
     }
 
     public int PageId { get; set; }
@@ -24,6 +27,8 @@ public class PageBlocksTagHelper : TagHelper
             .OrderBy(s => s.SortOrder)
             .Select(s => s.Html)
             .ToListAsync();
-        output.Content.SetHtmlContent(string.Join(System.Environment.NewLine, htmlParts));
+        var html = string.Join(System.Environment.NewLine, htmlParts);
+        html = await _tokens.RenderAsync(_db, html);
+        output.Content.SetHtmlContent(html);
     }
 }

--- a/website/MyWebApp/Views/AdminBlockTemplate/Create.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Create.cshtml
@@ -6,6 +6,20 @@
 <h2>Create Block</h2>
 <form asp-action="Create" method="post">
     <div><label>Name</label><input asp-for="Name" /></div>
-    <div><label>Html</label><textarea asp-for="Html"></textarea></div>
+    <div>
+        <label>Html</label>
+        <textarea asp-for="Html" id="html-area"></textarea>
+        <div class="insert-tools">
+            <button type="button" id="insert-block-btn">Insert Block</button>
+            <select id="block-select" style="display:none"></select>
+            <button type="button" id="insert-section-btn">Insert Section</button>
+            <select id="page-select" style="display:none"></select>
+            <select id="section-select" style="display:none"></select>
+        </div>
+    </div>
     <button type="submit">Save</button>
 </form>
+
+@section Scripts {
+    <script src="~/js/block-editor.js" asp-append-version="true"></script>
+}

--- a/website/MyWebApp/Views/AdminBlockTemplate/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/Edit.cshtml
@@ -7,6 +7,20 @@
 <form asp-action="Edit" method="post">
     <input type="hidden" asp-for="Id" />
     <div><label>Name</label><input asp-for="Name" /></div>
-    <div><label>Html</label><textarea asp-for="Html"></textarea></div>
+    <div>
+        <label>Html</label>
+        <textarea asp-for="Html" id="html-area"></textarea>
+        <div class="insert-tools">
+            <button type="button" id="insert-block-btn">Insert Block</button>
+            <select id="block-select" style="display:none"></select>
+            <button type="button" id="insert-section-btn">Insert Section</button>
+            <select id="page-select" style="display:none"></select>
+            <select id="section-select" style="display:none"></select>
+        </div>
+    </div>
     <button type="submit">Save</button>
 </form>
+
+@section Scripts {
+    <script src="~/js/block-editor.js" asp-append-version="true"></script>
+}

--- a/website/MyWebApp/wwwroot/js/block-editor.js
+++ b/website/MyWebApp/wwwroot/js/block-editor.js
@@ -1,0 +1,72 @@
+window.addEventListener('load', () => {
+    const html = document.getElementById('html-area');
+    if (!html) return;
+    const blockBtn = document.getElementById('insert-block-btn');
+    const blockSelect = document.getElementById('block-select');
+    const sectionBtn = document.getElementById('insert-section-btn');
+    const pageSelect = document.getElementById('page-select');
+    const sectionSelect = document.getElementById('section-select');
+
+    blockBtn?.addEventListener('click', () => {
+        fetch('/AdminBlockTemplate/GetBlocks')
+            .then(r => r.json())
+            .then(list => {
+                blockSelect.innerHTML = '<option value="">select</option>' +
+                    list.map(b => `<option value="${b.id}">${b.name}</option>`).join('');
+                blockSelect.style.display = 'inline';
+                blockSelect.focus();
+            });
+    });
+
+    blockSelect?.addEventListener('change', () => {
+        const id = blockSelect.value;
+        if (!id) return;
+        insertToken(`{{block:${id}}}`);
+        blockSelect.style.display = 'none';
+    });
+
+    sectionBtn?.addEventListener('click', () => {
+        fetch('/AdminBlockTemplate/GetPages')
+            .then(r => r.json())
+            .then(list => {
+                pageSelect.innerHTML = '<option value="">page</option>' +
+                    list.map(p => `<option value="${p.id}">${p.slug}</option>`).join('');
+                pageSelect.style.display = 'inline';
+                sectionSelect.style.display = 'none';
+                pageSelect.focus();
+            });
+    });
+
+    pageSelect?.addEventListener('change', () => {
+        const id = pageSelect.value;
+        if (!id) return;
+        fetch(`/AdminBlockTemplate/GetSections/${id}`)
+            .then(r => r.json())
+            .then(list => {
+                sectionSelect.innerHTML = '<option value="">area</option>' +
+                    list.map(a => `<option value="${a}">${a}</option>`).join('');
+                sectionSelect.style.display = 'inline';
+                sectionSelect.focus();
+            });
+    });
+
+    sectionSelect?.addEventListener('change', () => {
+        const pageId = pageSelect.value;
+        const area = sectionSelect.value;
+        if (!pageId || !area) return;
+        insertToken(`{{section:${pageId}:${area}}}`);
+        pageSelect.style.display = 'none';
+        sectionSelect.style.display = 'none';
+    });
+
+    function insertToken(text) {
+        if (html.selectionStart !== undefined) {
+            const start = html.selectionStart;
+            const end = html.selectionEnd;
+            html.value = html.value.substring(0, start) + text + html.value.substring(end);
+            html.selectionStart = html.selectionEnd = start + text.length;
+        } else {
+            html.value += text;
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- allow inserting block/section tokens in block template editor
- add token rendering service for recursive block lookup
- expose GetBlocks/GetPages/GetSections ajax endpoints
- register new service in DI
- include block-editor javascript
- update tests for new LayoutService dependency

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685117427838832c98e354cd339fe11f