### PR TITLE
Add layout header upgrade and navigation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ dotnet run
 3. For a quick reminder on how to import data manually,
    visit `/Setup/Import` while the site is running. The page shows the shell
    commands used to run the project and seed sample data.
+4. Restart the application (or open `/Setup`) after updating to ensure database
+   upgrades like the navigation token are applied.

--- a/website/MyWebApp.Tests/NavigationTests.cs
+++ b/website/MyWebApp.Tests/NavigationTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using MyWebApp.Data;
+using MyWebApp.Models;
+using MyWebApp.Services;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+public class NavigationTests
+{
+    [Fact]
+    public async Task PublishingPage_ShowsTitleOnceInHeader()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        var memory = new MemoryCache(new MemoryCacheOptions());
+        var cache = new CacheService(memory);
+        var tokens = new TokenRenderService();
+        var layout = new LayoutService(cache, tokens);
+
+        context.Pages.Add(new Page { Slug = "about", Title = "About", Layout = "single-column", IsPublished = true });
+        context.SaveChanges();
+
+        var html = await layout.GetHeaderAsync(context);
+
+        Assert.Contains("About", html);
+        Assert.Single(Regex.Matches(html, "About"));
+    }
+}

--- a/website/MyWebApp/Services/TokenRenderService.cs
+++ b/website/MyWebApp/Services/TokenRenderService.cs
@@ -21,7 +21,7 @@ public class TokenRenderService
             if (match.Value.StartsWith("{{nav", StringComparison.OrdinalIgnoreCase))
             {
                 var pages = await db.Pages.AsNoTracking()
-                    .Where(p => p.IsPublished && p.Slug != "layout")
+                    .Where(p => p.IsPublished && p.Slug != "layout" && p.Slug != "home")
                     .OrderBy(p => p.Title)
                     .Select(p => new { p.Slug, p.Title })
                     .ToListAsync();


### PR DESCRIPTION
## Summary
- ensure layout header has {{nav}} token via `UpgradeLayoutHeader`
- exclude `home` slug when rendering navigation links
- test that publishing a page adds the title once in the header
- document restart requirement for upgrades

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851343c27b8832ca484a42b7fab9c37