### PR TITLE
Externalize layout zones from config

### DIFF
--- a/website/MyWebApp.Tests/LayoutServiceTests.cs
+++ b/website/MyWebApp.Tests/LayoutServiceTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using MyWebApp.Services;
+using System.Collections.Generic;
+using Xunit;
+
+public class LayoutServiceTests
+{
+    [Fact]
+    public void CanReadZonesFromConfig()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                {"Layouts:single-column:0", "main"},
+                {"Layouts:two-column-sidebar:0", "main"},
+                {"Layouts:two-column-sidebar:1", "sidebar"}
+            })
+            .Build();
+        var memory = new MemoryCache(new MemoryCacheOptions());
+        var cache = new CacheService(memory);
+        var tokens = new TokenRenderService();
+        var service = new LayoutService(cache, tokens, config);
+
+        Assert.True(service.LayoutZones.ContainsKey("single-column"));
+        Assert.Contains("sidebar", service.LayoutZones["two-column-sidebar"]);
+    }
+}

--- a/website/MyWebApp.Tests/NavigationTests.cs
+++ b/website/MyWebApp.Tests/NavigationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
 using MyWebApp.Data;
 using MyWebApp.Models;
 using MyWebApp.Services;
@@ -23,7 +24,15 @@ public class NavigationTests
         var memory = new MemoryCache(new MemoryCacheOptions());
         var cache = new CacheService(memory);
         var tokens = new TokenRenderService();
-        var layout = new LayoutService(cache, tokens);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                {"Layouts:single-column:0", "main"},
+                {"Layouts:two-column-sidebar:0", "main"},
+                {"Layouts:two-column-sidebar:1", "sidebar"}
+            })
+            .Build();
+        var layout = new LayoutService(cache, tokens, config);
 
         context.Pages.Add(new Page { Slug = "about", Title = "About", Layout = "single-column", IsPublished = true });
         context.SaveChanges();

--- a/website/MyWebApp.Tests/SanitizationTests.cs
+++ b/website/MyWebApp.Tests/SanitizationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using MyWebApp.Controllers;
@@ -23,7 +24,15 @@ public class SanitizationTests
         var memory = new MemoryCache(new MemoryCacheOptions());
         var cache = new CacheService(memory);
         var tokens = new TokenRenderService();
-        var layout = new LayoutService(cache, tokens);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                {"Layouts:single-column:0", "main"},
+                {"Layouts:two-column-sidebar:0", "main"},
+                {"Layouts:two-column-sidebar:1", "sidebar"}
+            })
+            .Build();
+        var layout = new LayoutService(cache, tokens, config);
         var sanitizer = new HtmlSanitizerService();
         return (ctx, layout, sanitizer);
     }

--- a/website/MyWebApp/Controllers/AdminContentController.cs
+++ b/website/MyWebApp/Controllers/AdminContentController.cs
@@ -33,6 +33,7 @@ public class AdminContentController : Controller
             .OrderBy(t => t.Name).ToListAsync();
         ViewBag.Permissions = await _db.Permissions.AsNoTracking()
             .OrderBy(p => p.Name).ToListAsync();
+        ViewBag.LayoutZones = _layout.LayoutZones;
     }
 
     public async Task<IActionResult> Index()
@@ -65,7 +66,7 @@ public class AdminContentController : Controller
             model.PublishDate = DateTime.UtcNow;
         }
         var sections = model.Sections?.ToList() ?? new List<PageSection>();
-        if (sections.Any(s => !LayoutService.IsValidZone(model.Layout, s.Zone)))
+        if (sections.Any(s => !_layout.IsValidZone(model.Layout, s.Zone)))
         {
             ModelState.AddModelError(string.Empty, "Invalid area for selected layout.");
         }
@@ -131,7 +132,7 @@ public class AdminContentController : Controller
             model.PublishDate = DateTime.UtcNow;
         }
         var sections = model.Sections?.ToList() ?? new List<PageSection>();
-        if (sections.Any(s => !LayoutService.IsValidZone(model.Layout, s.Zone)))
+        if (sections.Any(s => !_layout.IsValidZone(model.Layout, s.Zone)))
         {
             ModelState.AddModelError(string.Empty, "Invalid area for selected layout.");
         }

--- a/website/MyWebApp/Controllers/AdminPageSectionController.cs
+++ b/website/MyWebApp/Controllers/AdminPageSectionController.cs
@@ -158,7 +158,7 @@ public class AdminPageSectionController : Controller
     public async Task<IActionResult> GetZonesForPage(int id)
     {
         var layout = await _db.Pages.Where(p => p.Id == id).Select(p => p.Layout).FirstOrDefaultAsync() ?? "single-column";
-        var zones = LayoutService.GetZones(layout);
+        var zones = _layout.GetZones(layout);
         return Json(zones);
     }
 }

--- a/website/MyWebApp/Controllers/PagesController.cs
+++ b/website/MyWebApp/Controllers/PagesController.cs
@@ -42,9 +42,9 @@ public class PagesController : BaseController
         }
 
         var layoutName = string.IsNullOrWhiteSpace(page.Layout) ? "single-column" : page.Layout;
-        if (!LayoutService.LayoutZones.TryGetValue(layoutName, out var zones))
+        if (!_layout.LayoutZones.TryGetValue(layoutName, out var zones))
         {
-            zones = LayoutService.LayoutZones["single-column"];
+            zones = _layout.LayoutZones["single-column"];
         }
         var zoneHtml = new Dictionary<string, string>();
         foreach (var z in zones)

--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -17,8 +17,13 @@
         <div>
             <label asp-for="Layout">Layout</label>
             <select asp-for="Layout" id="layout-select">
-                <option value="single-column">Single Column</option>
-                <option value="two-column-sidebar">Two Column with Sidebar</option>
+@if (ViewBag.LayoutZones is IReadOnlyDictionary<string, string[]> layouts)
+{
+    foreach (var entry in layouts)
+    {
+            <option value="@entry.Key">@entry.Key</option>
+    }
+}
             </select>
             <div id="layout-preview" class="layout-preview"></div>
         </div>
@@ -62,7 +67,7 @@
 </form>
 @section Scripts {
     <script>
-        const layoutZones = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(LayoutService.LayoutZones));
+        const layoutZones = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(ViewBag.LayoutZones));
     </script>
     <script src="~/js/page-editor.js" asp-append-version="true"></script>
     <script>

--- a/website/MyWebApp/appsettings.json
+++ b/website/MyWebApp/appsettings.json
@@ -17,6 +17,10 @@
   "Theme": {
     "Name": "dark"
   },
+  "Layouts": {
+    "single-column": [ "main" ],
+    "two-column-sidebar": [ "main", "sidebar" ]
+  },
   "Session": {
     "TimeoutMinutes": 30
   },


### PR DESCRIPTION
## Summary
- allow editing layout zones through configuration
- show layout options dynamically in admin UI
- update services and controllers to use config-driven layout zones
- update unit tests and add new LayoutServiceTests

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851502e13a0832c9590f78b828d6241