### PR TITLE
Task 4: Unify SectionEditor — single shared Quill partial

### DIFF
--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -1,6 +1,5 @@
 @model MyWebApp.Models.Page
 @using MyWebApp.Models
-@using MyWebApp.Services
 @using Microsoft.AspNetCore.Mvc.ViewFeatures
 @{
     var sections = ViewBag.Sections as List<PageSection> ?? new List<PageSection>();
@@ -44,7 +43,7 @@
 @for (int i = 0; i < sections.Count; i++)
 {
     var vd = new ViewDataDictionary(ViewData) { ["Index"] = i };
-    @await Html.PartialAsync("_SectionEditor", sections[i], vd)
+    @await Html.PartialAsync("~/Views/Shared/_SectionEditor.cshtml", sections[i], vd)
 }
     </div>
     @if (ViewBag.Templates is List<BlockTemplate> templates && templates.Count > 0)
@@ -61,7 +60,7 @@
     }
     <button type="button" id="add-section">Add Section</button>
     <div id="section-template" style="display:none">
-        @await Html.PartialAsync("_SectionEditor", new PageSection(), new ViewDataDictionary(ViewData) { ["Index"] = "__index__" })
+        @await Html.PartialAsync("~/Views/Shared/_SectionEditor.cshtml", new PageSection(), new ViewDataDictionary(ViewData) { ["Index"] = "__index__" })
     </div>
     <button type="submit">Save</button>
 </form>

--- a/website/MyWebApp/Views/AdminPageSection/Create.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Create.cshtml
@@ -16,7 +16,7 @@
         <select id="zone-select" asp-for="Zone" data-selected="@Model.Zone"></select>
     </div>
  
-@await Html.PartialAsync("_SectionEditor", Model)
+@await Html.PartialAsync("~/Views/Shared/_SectionEditor.cshtml", Model)
 
     <button type="submit">Save</button>
 </form>

--- a/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
@@ -17,7 +17,7 @@
         <select id="zone-select" asp-for="Zone" data-selected="@Model.Zone"></select>
     </div>
  
-@await Html.PartialAsync("_SectionEditor", Model)
+@await Html.PartialAsync("~/Views/Shared/_SectionEditor.cshtml", Model)
 
     <button type="submit">Save</button>
 </form>


### PR DESCRIPTION
## Summary
- update Razor views to reference the shared `_SectionEditor.cshtml`
- drop unused `MyWebApp.Services` using from `PageEditor` view

## Testing
- `dotnet test ../MyWebApp.Tests/MyWebApp.Tests.csproj -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68515e1a8820832cb851f1deeef02ee8