### PR TITLE
Fix JsonSerializer call

### DIFF
--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -66,7 +66,9 @@
 </form>
 @section Scripts {
     <script>
-        const layoutZones = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(ViewBag.LayoutZones));
+        const layoutZones = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
+            ViewBag.LayoutZones as IReadOnlyDictionary<string, string[]> ??
+            new Dictionary<string, string[]>()));
     </script>
     <script src="~/js/page-editor.js" asp-append-version="true"></script>
     <script>


### PR DESCRIPTION
## Summary
- fix JsonSerializer usage in PageEditor view to avoid RuntimeBinderException

## Testing
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_68519648aee0832cbc983f8a70d01ffb