### PR TITLE
Add live preview mode

### DIFF
--- a/website/MyWebApp/Models/PreviewRequest.cs
+++ b/website/MyWebApp/Models/PreviewRequest.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace MyWebApp.Models;
+
+public class PreviewRequest
+{
+    public string Layout { get; set; } = "single-column";
+    public string Title { get; set; } = string.Empty;
+    public Dictionary<string, string> Zones { get; set; } = new();
+}
+

--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -8,6 +8,15 @@
     ViewData["Title"] = isNew ? "Create Page" : "Edit Page";
 }
 <h2>@ViewData["Title"]</h2>
+<div class="mode-toggle">
+    <button type="button" id="mode-edit" class="mode-btn active">Edit</button>
+    <button type="button" id="mode-preview" class="mode-btn">Preview<span id="unsaved-indicator" class="unsaved-indicator">*</span></button>
+    <div class="device-buttons">
+        <button type="button" class="device-btn active" data-width="100%">Desktop</button>
+        <button type="button" class="device-btn" data-width="768px">Tablet</button>
+        <button type="button" class="device-btn" data-width="375px">Mobile</button>
+    </div>
+</div>
 <div class="page-editor">
     <aside id="block-library" class="block-library">
         <input type="text" id="block-search" class="search" placeholder="Search blocks..." />
@@ -69,6 +78,11 @@
     </div>
     <button type="submit">Save</button>
     </form>
+    <div id="preview-wrapper" class="preview-wrapper">
+        <div id="preview-container" class="preview-container">
+            <iframe id="preview-frame"></iframe>
+        </div>
+    </div>
 </div>
 @section Scripts {
     <script>

--- a/website/MyWebApp/wwwroot/css/admin.css
+++ b/website/MyWebApp/wwwroot/css/admin.css
@@ -1355,3 +1355,29 @@ form.mb-3 {
     text-overflow: ellipsis;
     margin-bottom: 0.25rem;
 }
+\n
+/* Live preview styles */
+.mode-toggle {
+    margin-bottom: 0.5rem;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+.mode-toggle .device-buttons {
+    margin-left: auto;
+    display: flex;
+    gap: 0.25rem;
+}
+.mode-btn.active,
+.device-btn.active {
+    background: #0ea5e9;
+    color: #fff;
+}
+.unsaved-indicator { color: #dc2626; margin-left: 0.25rem; display: none; }
+.preview-wrapper { display: none; margin-top: 1rem; }
+.page-editor.preview .editor-main,
+.page-editor.preview .block-library { display: none; }
+.page-editor.preview .preview-wrapper { display: block; }
+.preview-container { border: 1px solid #e2e8f0; margin: 0 auto; }
+.preview-container iframe { width: 100%; height: 600px; border: none; }
+


### PR DESCRIPTION
## Summary
- add PreviewRequest model for live previews
- inject TokenRenderService and add Preview action in AdminContentController
- enhance AdminContent/PageEditor with preview UI
- implement live preview logic in page-editor.js
- style preview elements in admin.css

## Testing
- `dotnet test website/MyWebApp.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3be1f84832cb6b83bbc025c715a