### PR TITLE
Fix section editor initialization

### DIFF
--- a/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
+++ b/website/MyWebApp/Views/AdminContent/PageEditor.cshtml
@@ -90,6 +90,7 @@
             ViewBag.LayoutZones as IReadOnlyDictionary<string, string[]> ??
             new Dictionary<string, string[]>()));
     </script>
+    <script src="~/js/section-editor.js" asp-append-version="true"></script>
     <script src="~/js/page-editor.js" asp-append-version="true"></script>
     <script src="~/js/block-library.js" asp-append-version="true"></script>
     <script>

--- a/website/MyWebApp/Views/AdminPageSection/Create.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Create.cshtml
@@ -20,4 +20,5 @@
 
     <button type="submit">Save</button>
 </form>
+<script src="~/js/section-editor.js" asp-append-version="true"></script>
 <script src="~/js/page-section-zone.js" asp-append-version="true"></script>

--- a/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
@@ -21,4 +21,5 @@
 
     <button type="submit">Save</button>
 </form>
+<script src="~/js/section-editor.js" asp-append-version="true"></script>
 <script src="~/js/page-section-zone.js" asp-append-version="true"></script>

--- a/website/MyWebApp/Views/Shared/_SectionEditor.cshtml
+++ b/website/MyWebApp/Views/Shared/_SectionEditor.cshtml
@@ -1,42 +1,33 @@
 @model MyWebApp.Models.PageSection
 @using MyWebApp.Models
-<div>
-    <label>Type</label>
-    <select asp-for="Type" asp-items="Html.GetEnumSelectList<PageSectionType>()" id="type-select"></select>
-</div>
-<div id="html-editor" class="type-editor">
-    <div class="quill-editor" id="quill-editor"></div>
-    <input type="hidden" asp-for="Html" />
-</div>
-<div id="markdown-editor" class="type-editor">
-    <textarea asp-for="Html"></textarea>
-</div>
-<div id="code-editor" class="type-editor">
-    <textarea asp-for="Html"></textarea>
-</div>
-    <div id="file-editor" class="type-editor">
-        <input type="file" name="file" />
+@{
+    var idxObj = ViewData["Index"];
+    var idx = idxObj?.ToString() ?? "0";
+    var prefix = idxObj != null ? $"Sections[{idx}]." : string.Empty;
+}
+<div class="section-editor" data-index="@idx" draggable="true">
+    <input type="hidden" name="@($"{prefix}Id")" value="@Model.Id" />
+    <input type="hidden" name="@($"{prefix}SortOrder")" value="@Model.SortOrder" class="sort-order" />
+    <div>
+        <label>Zone</label>
+        <select class="zone-select" data-index="@idx" name="@($"{prefix}Zone")" data-selected="@Model.Zone"></select>
+    </div>
+    <div>
+        <label>Type</label>
+        <select id="type-select-@idx" name="@($"{prefix}Type")" asp-items="Html.GetEnumSelectList<PageSectionType>()" value="@Model.Type"></select>
+    </div>
+    <div id="html-editor-@idx" class="type-editor">
+        <div class="quill-editor" id="quill-editor-@idx"></div>
+        <input type="hidden" id="Html-@idx" name="@($"{prefix}Html")" value="@Model.Html" />
+    </div>
+    <div id="markdown-editor-@idx" class="type-editor">
+        <textarea id="Markdown-@idx" name="@($"{prefix}Html")">@Model.Html</textarea>
+    </div>
+    <div id="code-editor-@idx" class="type-editor">
+        <textarea id="Code-@idx" name="@($"{prefix}Html")">@Model.Html</textarea>
+    </div>
+    <div id="file-editor-@idx" class="type-editor">
+        <input type="file" name="@($"{prefix}File")" />
     </div>
     <button type="button" class="add-library">Add to Library</button>
-    <script>
-    const typeSelect = document.getElementById('type-select');
-    const htmlDiv = document.getElementById('html-editor');
-    const markdownDiv = document.getElementById('markdown-editor');
-    const codeDiv = document.getElementById('code-editor');
-    const fileDiv = document.getElementById('file-editor');
-    const quill = new Quill('#quill-editor', { theme: 'snow' });
-    quill.root.innerHTML = document.getElementById('Html').value;
-    function updateEditors() {
-        htmlDiv.style.display = typeSelect.value == 'Html' ? 'block' : 'none';
-        markdownDiv.style.display = typeSelect.value == 'Markdown' ? 'block' : 'none';
-        codeDiv.style.display = typeSelect.value == 'Code' ? 'block' : 'none';
-        fileDiv.style.display = (typeSelect.value == 'Image' || typeSelect.value == 'Video') ? 'block' : 'none';
-    }
-    updateEditors();
-    typeSelect.addEventListener('change', updateEditors);
-    document.querySelector('form').addEventListener('submit', function () {
-        if (typeSelect.value === 'Html') {
-            document.getElementById('Html').value = quill.root.innerHTML;
-        }
-    });
-</script>
+</div>

--- a/website/MyWebApp/wwwroot/js/block-library.js
+++ b/website/MyWebApp/wwwroot/js/block-library.js
@@ -36,7 +36,8 @@ window.addEventListener('load', () => {
     list.addEventListener('dragstart', e => {
         const card = e.target.closest('.block-card');
         if (!card) return;
-        window.draggedBlockId = card.dataset.id;
+        const ev = new CustomEvent('blockdragstart', { detail: card.dataset.id });
+        document.dispatchEvent(ev);
         e.dataTransfer.effectAllowed = 'copy';
     });
 });

--- a/website/MyWebApp/wwwroot/js/section-editor.js
+++ b/website/MyWebApp/wwwroot/js/section-editor.js
@@ -1,0 +1,39 @@
+(() => {
+    const editors = new WeakMap();
+
+    function init(container) {
+        if (!container) return;
+        const index = container.dataset.index;
+        const typeSelect = container.querySelector(`#type-select-${index}`);
+        const htmlDiv = container.querySelector(`#html-editor-${index}`);
+        const markdownDiv = container.querySelector(`#markdown-editor-${index}`);
+        const codeDiv = container.querySelector(`#code-editor-${index}`);
+        const fileDiv = container.querySelector(`#file-editor-${index}`);
+        const quillInput = container.querySelector(`#Html-${index}`);
+        if (!typeSelect || !quillInput) return;
+        const quill = new Quill(`#quill-editor-${index}`, { theme: 'snow' });
+        quill.root.innerHTML = quillInput.value || '';
+        quill.on('text-change', () => {
+            quillInput.value = quill.root.innerHTML;
+            container.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+        editors.set(container, quill);
+        container.dispatchEvent(new CustomEvent('section-editor:ready', { detail: { quill, index } }));
+
+        function update() {
+            const type = typeSelect.value;
+            if (htmlDiv) htmlDiv.style.display = type === 'Html' ? 'block' : 'none';
+            if (markdownDiv) markdownDiv.style.display = type === 'Markdown' ? 'block' : 'none';
+            if (codeDiv) codeDiv.style.display = type === 'Code' ? 'block' : 'none';
+            if (fileDiv) fileDiv.style.display = (type === 'Image' || type === 'Video') ? 'block' : 'none';
+        }
+        typeSelect.addEventListener('change', update);
+        update();
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('.section-editor').forEach(init);
+    });
+
+    document.addEventListener('section-editor:add', e => init(e.detail));
+})();


### PR DESCRIPTION
## Summary
- add dynamic IDs and remove inline JS from section editor partial
- centralize Quill initialization in new `section-editor.js`
- refactor `page-editor.js` and `block-library.js` to use custom events
- sanitize preview content on the server and add CSP header
- update tests for new controller constructor

## Testing
- `./setup.sh` *(fails: LIB002 errors)*
- `dotnet test MyWebApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851a839448c832c821cda04b4ce6bab