### PR TITLE
Enhance admin block UI

### DIFF
--- a/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
@@ -7,8 +7,13 @@
 <form asp-action="AddToPage" method="post">
     <input type="hidden" name="id" value="@ViewBag.BlockId" />
     <div>
-        <label>Page</label>
-        <select name="pageId">
+        <label>Associated Page(s)</label>
+        <input type="text" id="page-display" readonly />
+    </div>
+    <div>
+        <label>Assign To Pages</label>
+        <select id="page-select" name="pageIds" multiple size="5">
+            <option value="0">All Pages</option>
             @foreach (var p in ViewBag.Pages as List<Page>)
             {
                 <option value="@p.Id">@p.Slug</option>
@@ -21,13 +26,25 @@
     </div>
     <div>
         <label>Role</label>
-        <select name="roleId">
-            <option value="">(none)</option>
-            @foreach (var r in ViewBag.Roles as List<Role>)
-            {
-                <option value="@r.Id">@r.Name</option>
-            }
+        <select name="role" required>
+            <option value="">Select role</option>
+            <option value="Admin">Admin</option>
+            <option value="Editor">Editor</option>
+            <option value="Viewer">Viewer</option>
         </select>
     </div>
     <button type="submit">Add</button>
 </form>
+
+@section Scripts {
+    <script>
+        const select = document.getElementById('page-select');
+        const display = document.getElementById('page-display');
+        function updateDisplay() {
+            const names = Array.from(select.selectedOptions).map(o => o.text);
+            display.value = names.join(', ');
+        }
+        select.addEventListener('change', updateDisplay);
+        updateDisplay();
+    </script>
+}

--- a/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
+++ b/website/MyWebApp/Views/AdminPageSection/Edit.cshtml
@@ -10,6 +10,10 @@
 <form asp-action="Edit" method="post" enctype="multipart/form-data">
     <input type="hidden" asp-for="Id" />
     <div>
+        <label>Associated Page</label>
+        <input type="text" readonly value="@pages.FirstOrDefault(p => p.Id == Model.PageId)?.Slug" />
+    </div>
+    <div>
         <label>Page</label>
         <select asp-for="PageId" asp-items="@(new SelectList(pages, "Id", "Slug"))"></select>
     </div>

--- a/website/MyWebApp/Views/Shared/_SectionEditor.cshtml
+++ b/website/MyWebApp/Views/Shared/_SectionEditor.cshtml
@@ -15,12 +15,11 @@
     </div>
     <div>
         <label>Role</label>
-        <select name="@($"{prefix}RoleId")">
-            <option value="">(none)</option>
-            @foreach (var r in roles)
-            {
-                <option value="@r.Id" selected="@(Model.RoleId == r.Id)">@r.Name</option>
-            }
+        <select name="@($"{prefix}RoleId")" required>
+            <option value="">Select role</option>
+            <option value="1" selected="@(Model.RoleId == 1)">Admin</option>
+            <option value="2" selected="@(Model.RoleId == 2)">Editor</option>
+            <option value="3" selected="@(Model.RoleId == 3)">Viewer</option>
         </select>
     </div>
     <div>


### PR DESCRIPTION
## Summary
- show currently selected pages when adding blocks
- add role dropdown with Admin, Editor and Viewer options
- allow assigning a block to multiple pages
- display associated page on edit section view

## Testing
- `dotnet test MyWebApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525913c768832ca8fd40a09bfe4721