### PR TITLE
Implement zone dropdowns for block templates

### DIFF
--- a/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
+++ b/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
@@ -28,6 +28,11 @@ public class AdminBlockTemplateController : Controller
     {
         ViewBag.Pages = await _db.Pages.AsNoTracking().OrderBy(p => p.Slug).ToListAsync();
         ViewBag.Roles = await _db.Roles.AsNoTracking().OrderBy(r => r.Name).ToListAsync();
+        ViewBag.Zones = await _db.PageSections.AsNoTracking()
+            .Select(s => s.Zone)
+            .Distinct()
+            .OrderBy(z => z)
+            .ToListAsync();
     }
 
     public async Task<IActionResult> Index()

--- a/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
@@ -22,7 +22,12 @@
     </div>
     <div>
         <label>Zone</label>
-        <input type="text" name="zone" />
+        <select id="zone-select" name="zone">
+            @foreach (var z in ViewBag.Zones as List<string>)
+            {
+                <option value="@z">@z</option>
+            }
+        </select>
     </div>
     <div>
         <label>Role</label>

--- a/website/MyWebApp/Views/AdminBlockTemplate/_PageAssignment.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/_PageAssignment.cshtml
@@ -14,7 +14,12 @@
     </div>
     <div>
         <label>Zone</label>
-        <input type="text" name="zone" />
+        <select id="zone-select" name="zone">
+            @foreach (var z in ViewBag.Zones as List<string>)
+            {
+                <option value="@z">@z</option>
+            }
+        </select>
     </div>
     <div>
         <label>Role</label>


### PR DESCRIPTION
## Summary
- fetch available zones from `PageSections`
- use dropdowns for zone selection in block views

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852679917d4832ca97b051e11b78dea