### PR TITLE
Fix admin block assignment selection state

### DIFF
--- a/website/MyWebApp.Tests/AdminBlockTemplateControllerTests.cs
+++ b/website/MyWebApp.Tests/AdminBlockTemplateControllerTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using MyWebApp.Controllers;
+using MyWebApp.Data;
+using MyWebApp.Models;
+using MyWebApp.Services;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class AdminBlockTemplateControllerTests
+{
+    private static (AdminBlockTemplateController controller, ApplicationDbContext ctx, SqliteConnection conn) Create()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(conn)
+            .Options;
+        var ctx = new ApplicationDbContext(options);
+        ctx.Database.EnsureCreated();
+        var sanitizer = new HtmlSanitizerService();
+        var controller = new AdminBlockTemplateController(ctx, sanitizer);
+        return (controller, ctx, conn);
+    }
+
+    [Fact]
+    public async Task AddToPage_InvalidReturnsViewWithSelections()
+    {
+        var tuple = Create();
+        using var connection = tuple.conn;
+        var ctx = tuple.ctx;
+        var controller = tuple.controller;
+        ctx.BlockTemplates.Add(new BlockTemplate { Id = 1, Name = "b", Html = "x" });
+        ctx.Pages.Add(new Page { Id = 1, Slug = "home", Title = "Home", Layout = "single-column" });
+        ctx.Roles.Add(new Role { Id = 1, Name = "Admin" });
+        ctx.SaveChanges();
+
+        var result = await controller.AddToPage(1, new List<int> { 1 }, "", "Admin");
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.False(controller.ModelState.IsValid);
+        var selected = Assert.IsType<List<int>>(controller.ViewBag.SelectedPageIds);
+        Assert.Contains(1, selected);
+        Assert.Equal("", controller.ViewBag.SelectedZone as string);
+        Assert.Equal("Admin", controller.ViewBag.SelectedRole as string);
+    }
+
+    [Fact]
+    public async Task Create_InvalidModelPreservesSelections()
+    {
+        var tuple = Create();
+        using var connection = tuple.conn;
+        var ctx = tuple.ctx;
+        var controller = tuple.controller;
+        ctx.Pages.Add(new Page { Id = 1, Slug = "home", Title = "Home", Layout = "single-column" });
+        ctx.Roles.Add(new Role { Id = 1, Name = "Admin" });
+        ctx.SaveChanges();
+
+        var model = new BlockTemplate();
+        controller.ModelState.AddModelError("Name", "required");
+        var result = await controller.Create(model, new List<int> { 1 }, "main", "Admin");
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.False(controller.ModelState.IsValid);
+        var selected = Assert.IsType<List<int>>(controller.ViewBag.SelectedPageIds);
+        Assert.Contains(1, selected);
+        Assert.Equal("main", controller.ViewBag.SelectedZone as string);
+        Assert.Equal("Admin", controller.ViewBag.SelectedRole as string);
+    }
+}

--- a/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
+++ b/website/MyWebApp/Controllers/AdminBlockTemplateController.cs
@@ -54,6 +54,9 @@ public class AdminBlockTemplateController : Controller
         if (!ModelState.IsValid)
         {
             await LoadPagesAsync();
+            ViewBag.SelectedPageIds = pageIds ?? new List<int>();
+            ViewBag.SelectedZone = zone;
+            ViewBag.SelectedRole = role;
             return View(model);
         }
         model.Html = _sanitizer.Sanitize(model.Html);
@@ -80,6 +83,9 @@ public class AdminBlockTemplateController : Controller
         if (!ModelState.IsValid)
         {
             await LoadPagesAsync();
+            ViewBag.SelectedPageIds = pageIds ?? new List<int>();
+            ViewBag.SelectedZone = zone;
+            ViewBag.SelectedRole = role;
             return View(model);
         }
         model.Html = _sanitizer.Sanitize(model.Html);
@@ -175,6 +181,9 @@ public class AdminBlockTemplateController : Controller
         if (item == null) return NotFound();
         await LoadPagesAsync();
         ViewBag.BlockId = id;
+        ViewBag.SelectedPageIds = new List<int>();
+        ViewBag.SelectedZone = string.Empty;
+        ViewBag.SelectedRole = string.Empty;
         return View();
     }
 
@@ -188,6 +197,9 @@ public class AdminBlockTemplateController : Controller
         {
             await LoadPagesAsync();
             ViewBag.BlockId = id;
+            ViewBag.SelectedPageIds = pageIds ?? new List<int>();
+            ViewBag.SelectedZone = zone;
+            ViewBag.SelectedRole = role;
             ModelState.AddModelError("pageIds", "Page selection required");
             return View();
         }
@@ -198,6 +210,9 @@ public class AdminBlockTemplateController : Controller
         {
             await LoadPagesAsync();
             ViewBag.BlockId = id;
+            ViewBag.SelectedPageIds = pageIds;
+            ViewBag.SelectedZone = zone;
+            ViewBag.SelectedRole = role;
             ModelState.AddModelError("zone", "Zone required");
             return View();
         }

--- a/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/AddToPage.cshtml
@@ -1,5 +1,10 @@
 @using MyWebApp.Models
 @{
+    var selectedPages = ViewBag.SelectedPageIds as List<int> ?? new List<int>();
+    var selectedZone = ViewBag.SelectedZone as string ?? string.Empty;
+    var selectedRole = ViewBag.SelectedRole as string ?? string.Empty;
+}
+@{
     ViewData["Title"] = "Add Block To Page";
     Layout = "../Admin/_AdminLayout";
 }
@@ -13,10 +18,10 @@
     <div>
         <label>Assign To Pages</label>
         <select id="page-select" name="pageIds" multiple size="5">
-            <option value="0">All Pages</option>
+            <option value="0" selected="@(selectedPages.Contains(0))">All Pages</option>
             @foreach (var p in ViewBag.Pages as List<Page>)
             {
-                <option value="@p.Id">@p.Slug</option>
+                <option value="@p.Id" selected="@(selectedPages.Contains(p.Id))">@p.Slug</option>
             }
         </select>
     </div>
@@ -25,20 +30,20 @@
         <select id="zone-select" name="zone">
             @foreach (var z in ViewBag.Zones as List<string>)
             {
-                <option value="@z">@z</option>
+                <option value="@z" selected="@(selectedZone == z)">@z</option>
             }
         </select>
     </div>
     <div>
         <label>Role</label>
- 
+
         <select name="role">
-            <option value="">(none)</option>
+            <option value="" selected="@(string.IsNullOrEmpty(selectedRole))">(none)</option>
             @foreach (var r in ViewBag.Roles as List<Role>)
             {
-                <option value="@r.Name">@r.Name</option>
+                <option value="@r.Name" selected="@(selectedRole == r.Name)">@r.Name</option>
             }
- 
+
         </select>
     </div>
     <button type="submit">Add</button>

--- a/website/MyWebApp/Views/AdminBlockTemplate/_PageAssignment.cshtml
+++ b/website/MyWebApp/Views/AdminBlockTemplate/_PageAssignment.cshtml
@@ -1,14 +1,19 @@
 @using MyWebApp.Models
+@{
+    var selectedPages = ViewBag.SelectedPageIds as List<int> ?? new List<int>();
+    var selectedZone = ViewBag.SelectedZone as string ?? string.Empty;
+    var selectedRole = ViewBag.SelectedRole as string ?? string.Empty;
+}
 <div class="block-assignment">
     <h3>Page Assignment</h3>
     <div>
         <label>Pages</label>
         <input type="text" id="page-display" readonly />
         <select id="page-select" name="pageIds" multiple size="5">
-            <option value="0">All Pages</option>
+            <option value="0" selected="@(selectedPages.Contains(0))">All Pages</option>
             @foreach (var p in ViewBag.Pages as List<Page>)
             {
-                <option value="@p.Id">@p.Slug</option>
+                <option value="@p.Id" selected="@(selectedPages.Contains(p.Id))">@p.Slug</option>
             }
         </select>
     </div>
@@ -17,17 +22,17 @@
         <select id="zone-select" name="zone">
             @foreach (var z in ViewBag.Zones as List<string>)
             {
-                <option value="@z">@z</option>
+                <option value="@z" selected="@(selectedZone == z)">@z</option>
             }
         </select>
     </div>
     <div>
         <label>Role</label>
         <select name="role">
-            <option value="">(none)</option>
+            <option value="" selected="@(string.IsNullOrEmpty(selectedRole))">(none)</option>
             @foreach (var r in ViewBag.Roles as List<Role>)
             {
-                <option value="@r.Name">@r.Name</option>
+                <option value="@r.Name" selected="@(selectedRole == r.Name)">@r.Name</option>
             }
         </select>
     </div>


### PR DESCRIPTION
## Summary
- keep drop-down selections when adding or editing block templates
- render selected values in `AddToPage` and `_PageAssignment`
- expose selected options from controller for invalid posts
- test the controller behaviour

## Testing
- `dotnet test MyWebApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526ed164c4832c8d0da24120a37991